### PR TITLE
Fixed relative link checking for local input files.

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,6 +4,9 @@ var _ = require('lodash');
 var async = require('async');
 var linkCheck = require('link-check');
 var markdownLinkExtractor = require('markdown-link-extractor');
+var isRelativeUrl = require('is-relative-url');
+var fs = require('fs');
+var url = require('url');
 
 module.exports = function markdownLinkCheck(markdown, opts, callback) {
     if (arguments.length === 2 && typeof opts === 'function') {
@@ -12,7 +15,24 @@ module.exports = function markdownLinkCheck(markdown, opts, callback) {
         opts = {};
     }
 
+    var isSourceRelative = isRelativeUrl(opts.baseUrl)
+
     async.mapLimit(_.uniq(markdownLinkExtractor(markdown)), 2, function (link, callback) {
-        linkCheck(link, opts, callback);
+        if (isSourceRelative && isRelativeUrl(link)) {
+            var resolvedLink = url.resolve(opts.baseUrl, link)
+
+            fs.access(resolvedLink, fs.constants.F_OK, function (err) {
+              var result = {};
+              result.link = resolvedLink;
+              result.statusCode = (err === null) ? 200 : 404;
+              result.err = err;
+              result.status = (err === null) ? 'alive' : 'dead';
+
+              callback(err, result);
+            });
+        }
+        else {
+            linkCheck(link, opts, callback);
+        }
     }, callback);
 };

--- a/index.js
+++ b/index.js
@@ -15,11 +15,11 @@ module.exports = function markdownLinkCheck(markdown, opts, callback) {
         opts = {};
     }
 
-    var isSourceRelative = isRelativeUrl(opts.baseUrl)
+    var isSourceRelative = isRelativeUrl(opts.baseUrl);
 
     async.mapLimit(_.uniq(markdownLinkExtractor(markdown)), 2, function (link, callback) {
         if (isSourceRelative && isRelativeUrl(link)) {
-            var resolvedLink = url.resolve(opts.baseUrl, link)
+            var resolvedLink = url.resolve(opts.baseUrl, link);
 
             fs.access(resolvedLink, fs.constants.F_OK, function (err) {
               var result = {};
@@ -30,8 +30,7 @@ module.exports = function markdownLinkCheck(markdown, opts, callback) {
 
               callback(err, result);
             });
-        }
-        else {
+        } else {
             linkCheck(link, opts, callback);
         }
     }, callback);

--- a/markdown-link-check
+++ b/markdown-link-check
@@ -31,7 +31,7 @@ program.arguments('[filenameOrUrl]').action(function (filenameOrUrl) {
         } catch (err) { /* ignore error */ }
     } else {
         stream = fs.createReadStream(filenameOrUrl);
-        opts.baseUrl = filenameOrUrl
+        opts.baseUrl = filenameOrUrl;
     }
 }).parse(process.argv);
 

--- a/markdown-link-check
+++ b/markdown-link-check
@@ -31,6 +31,7 @@ program.arguments('[filenameOrUrl]').action(function (filenameOrUrl) {
         } catch (err) { /* ignore error */ }
     } else {
         stream = fs.createReadStream(filenameOrUrl);
+        opts.baseUrl = filenameOrUrl
     }
 }).parse(process.argv);
 

--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "link-check": "^3.0.1",
     "markdown-link-extractor": "^1.1.0",
     "request": "^2.76.0",
-    "lodash": "^4.16.4"
+    "lodash": "^4.16.4",
+    "is-relative-url": "^2.0.0"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",

--- a/test/markdown-link-check.test.js
+++ b/test/markdown-link-check.test.js
@@ -10,7 +10,7 @@ var markdownLinkCheck = require('../');
 describe('markdown-link-check', function () {
 
     var baseUrl;
-    
+
     before(function (done) {
         var app = express();
 
@@ -38,7 +38,7 @@ describe('markdown-link-check', function () {
                 dotfiles: 'deny'
             });
         });
-        
+
         var server = http.createServer(app);
         server.listen(0 /* random open port */, 'localhost', function serverListen(err) {
             if (err) {
@@ -86,7 +86,7 @@ describe('markdown-link-check', function () {
         for (var i = 0; i < nlinks; i++) {
             md += '[test](' + baseUrl + '/foo/bar?i=' + i + ')\n';
         }
-        markdownLinkCheck(md, function (err, results) {
+        markdownLinkCheck(md, { baseUrl: baseUrl }, function (err, results) {
             expect(err).to.be(null);
             expect(results).to.be.an('array');
             expect(results).to.have.length(nlinks);


### PR DESCRIPTION
The link checker will correctly evaluate a relative URL contained within markdown when a remote URL is specified as a CLI argument that contains a relative link. But it failed when a local filename was specified instead. This patch addresses that issue by considering whether the markdown source URL is local.