### PR TITLE
set basePath for local files

### DIFF
--- a/markdown-link-check
+++ b/markdown-link-check
@@ -31,7 +31,7 @@ program.arguments('[filenameOrUrl]').action(function (filenameOrUrl) {
             opts.baseUrl = url.format(parsed);
         } catch (err) { /* ignore error */ }
     } else {
-        opts.baseUrl = 'file://' + path.dirname(path.resolve(filenameOrUrl))
+        opts.baseUrl = 'file://' + path.dirname(path.resolve(filenameOrUrl));
         stream = fs.createReadStream(filenameOrUrl);
     }
 }).parse(process.argv);

--- a/markdown-link-check
+++ b/markdown-link-check
@@ -8,6 +8,7 @@ var markdownLinkCheck = require('./');
 var program = require('commander');
 var request = require('request');
 var url = require('url');
+var path = require('path');
 
 var statusLabels = {
     alive: chalk.green('✓'),
@@ -30,6 +31,7 @@ program.arguments('[filenameOrUrl]').action(function (filenameOrUrl) {
             opts.baseUrl = url.format(parsed);
         } catch (err) { /* ignore error */ }
     } else {
+        opts.baseUrl = 'file://' + path.dirname(path.resolve(filenameOrUrl))
         stream = fs.createReadStream(filenameOrUrl);
     }
 }).parse(process.argv);


### PR DESCRIPTION
set basePath for local files to directory that contains the file

it is required for checking local markdown files that have links to other local files as there is no way to pass basePath from the CLI

and without the basePath it would crash with:
```
url.js:95
    throw new TypeError('Parameter "url" must be a string, not ' + typeof url);
    ^

TypeError: Parameter "url" must be a string, not undefined
    at Url.parse (url.js:95:11)
    at Object.urlParse [as parse] (url.js:89:5)
    at linkCheck (node_modules/link-check/index.js:19:68)
    at node_modules/markdown-link-check/index.js:16:9
    at node_modules/async/dist/async.js:1008:9
    at replenish (node_modules/async/dist/async.js:882:17)
    at node_modules/async/dist/async.js:886:9
    at _asyncMap (node_modules/async/dist/async.js:1006:5)
    at Object.mapLimit (node_modules/async/dist/async.js:1092:16)
    at markdownLinkCheck (node_modules/markdown-link-check/index.js:15:11)
```