### PR TITLE
Added command line switch to show progress

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ If not supplied, the tool reads from standard input.
 
     cat *.md | markdown-link-check
 
+##### Command Line Switch
+Add a `--progress` or `-p` switch to view progress. (Optional)
+
+    markdown-link-check ./README.md -p
+
 ## Testing
 
     npm test

--- a/index.js
+++ b/index.js
@@ -4,6 +4,13 @@ var _ = require('lodash');
 var async = require('async');
 var linkCheck = require('link-check');
 var markdownLinkExtractor = require('markdown-link-extractor');
+var ProgressBar = require('progress');
+var bar;
+var showProgressBar = false;
+
+if (_.includes(process.argv, "--progress") || _.includes(process.argv, "-p")) {
+    showProgressBar = true;
+}
 
 module.exports = function markdownLinkCheck(markdown, opts, callback) {
     if (arguments.length === 2 && typeof opts === 'function') {
@@ -12,7 +19,20 @@ module.exports = function markdownLinkCheck(markdown, opts, callback) {
         opts = {};
     }
 
-    async.mapLimit(_.uniq(markdownLinkExtractor(markdown)), 2, function (link, callback) {
+    var linksCollection = _.uniq(markdownLinkExtractor(markdown));
+    if (showProgressBar) {
+        bar = bar || new ProgressBar('Checking... [:bar] :percent', {
+            complete: '=',
+            incomplete: ' ',
+            width: 25,
+            total: linksCollection.length
+        });
+    }
+
+    async.mapLimit(linksCollection, 2, function (link, callback) {
         linkCheck(link, opts, callback);
+        if (showProgressBar) {
+            bar.tick();
+        }
     }, callback);
 };

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "markdown-link-check",
-  "version": "3.0.3",
+  "version": "3.0.4",
   "description": "checks the all of the hyperlinks in a markdown text to determine if they are alive or dead",
   "bin": {
     "markdown-link-check": "markdown-link-check"
@@ -36,7 +36,8 @@
     "link-check": "^4.0.2",
     "markdown-link-extractor": "^1.1.0",
     "request": "^2.79.0",
-    "lodash": "^4.17.4"
+    "lodash": "^4.17.4",
+    "progress":"^2.0.0"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",


### PR DESCRIPTION
Adds a progress bar to notify user about status, similar to following:
```
markdown-link-check https://github.com/tcort/markdown-link-check/blob/master/README.md -p
Checking... [=========================] 100%
[✓] http://example.com
[✓] https://github.com/tcort/markdown-link-check/blob/master/README.md
```
Only shows a progress bar:
- If running via command line
- And `-p` or  `--progress` switch is passed as an argument

Why?
- Helpful when its processing files with many links
- Good UI practice

Bumped up patch in `package.json`. All tests are passing, let me know if this needs modifications.

Thanks.