### PR TITLE
Added console message to show when there are no hyperlinks

### DIFF
--- a/markdown-link-check
+++ b/markdown-link-check
@@ -43,6 +43,9 @@ stream.on('data', function (chunk) {
     markdown += chunk.toString();
 }).on('end', function () {
     markdownLinkCheck(markdown, opts, function (err, results) {
+        if (results.length === 0){
+            console.log(chalk.yellow('No hyperlinks found!'));
+        }
         results.forEach(function (result) {
             if(result.status === 'dead') {
                 error = true;


### PR DESCRIPTION
Currently when you run the command utility, if there are no hyperlinks, there is no onscreen output. 

This PR adds a the message `No hyperlinks found` for such cases.

Test Report:
```bash
$ npm test

> markdown-link-check@3.1.1 pretest /home/user/Documents/learning/OpenSource/markdown-link-check
> jshint index.js markdown-link-check


> markdown-link-check@3.1.1 test /home/user/Documents/learning/OpenSource/markdown-link-check
> mocha -R spec



  markdown-link-check
    ✓ should check the links in sample.md (470ms)
    ✓ should check the links in file.md
    ✓ should handle thousands of links (this test takes up to a minute) (9858ms)


  3 passing (10s)
```