### PR TITLE
go lean: removes lodash dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,5 @@
 'use strict';
 
-var _ = require('lodash');
 var async = require('async');
 var linkCheck = require('link-check');
 var markdownLinkExtractor = require('markdown-link-extractor');
@@ -14,7 +13,7 @@ module.exports = function markdownLinkCheck(markdown, opts, callback) {
     }
 
     var bar;
-    var linksCollection = _.uniq(markdownLinkExtractor(markdown));
+    var linksCollection = Array.from(new Set(markdownLinkExtractor(markdown)));
     if (opts.showProgressBar) {
         bar = new ProgressBar('Checking... [:bar] :percent', {
             complete: '=',

--- a/package.json
+++ b/package.json
@@ -36,7 +36,6 @@
     "link-check": "^4.3.3",
     "markdown-link-extractor": "^1.1.1",
     "request": "^2.83.0",
-    "lodash": "^4.17.4",
     "progress": "^2.0.0"
   },
   "devDependencies": {


### PR DESCRIPTION
Helps cutting down on a dependency.
 - Replaces lodash uniq with [Set](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Set)