### PR TITLE
Replacement patterns to support platform specific conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,6 +42,7 @@ Parameters:
   * `showProgressBar` enable an ASCII progress bar.
   * `httpHeaders` to apply URL specific headers, see example below.
   * `ignorePatterns` an array of objects holding regular expressions which a link is checked against and skipped for checking in case of a match. Example: `[{ pattern: /foo/ }]`
+  * `replacementPatterns` an array of objects holding regular expressions which are replaced in a link with their corresponding replacement string. This behavior allows (for example) to adapt to certain platform conventions hosting the Markdown. Example: `[{ pattern: /^.attachments/, replacement: "file://some/conventional/folder/.attachments" }]`
 * `callback` function which accepts `(err, results)`.
   * `err` an Error object when the operation cannot be completed, otherwise `null`.
   * `results` an array of objects with the following properties:
@@ -131,7 +132,7 @@ If not supplied, the tool reads from standard input.
 `config.json`:
 
 * `ignorePatterns`: An array of objects holding regular expressions which a link is checked against and skipped for checking in case of a match.
-* `replacementPatterns`: An array of objects holding regular expressions which are replaced in a link with their corresponding replacement string. This behavior allows to adapt to certain platform conventions hosting the Markdown.
+* `replacementPatterns`: An array of objects holding regular expressions which are replaced in a link with their corresponding replacement string. This behavior allows (for example) to adapt to certain platform conventions hosting the Markdown.
 * `httpHeaders`: The headers are only applied to links where the link **starts with** one of the supplied URLs in the `urls` section.
 
 **Example:**
@@ -145,7 +146,7 @@ If not supplied, the tool reads from standard input.
         "replacementPatterns": [
             {
                 "pattern": "^.attachments",
-                "replacement": "file://C:\foo\bar\.attachments"
+                "replacement": "file://some/conventional/folder/.attachments"
             }
         ],
         "httpHeaders": [

--- a/README.md
+++ b/README.md
@@ -120,7 +120,7 @@ If not supplied, the tool reads from standard input.
   Options:
 
     -p, --progress         show progress bar
-    -c, --config [config]  apply a config file (JSON), holding e.g. URL specific header configuration
+    -c, --config [config]  apply a configuration file (JSON)
     -q, --quiet            display errors only
     -h, --help             output usage information
 
@@ -130,10 +130,24 @@ If not supplied, the tool reads from standard input.
 
 `config.json`:
 
+* `ignorePatterns`: An array of objects holding regular expressions which a link is checked against and skipped for checking in case of a match.
+* `replacementPatterns`: An array of objects holding regular expressions which are replaced in a link with their corresponding replacement string. This behavior allows to adapt to certain platform conventions hosting the Markdown.
+* `httpHeaders`: The headers are only applied to links where the link **starts with** one of the supplied URLs in the `urls` section.
+
+**Example:**
+
     {
         "ignorePatterns": [
-            { pattern: "^http://example.net" }
-        ]
+            {
+                "pattern": "^http://example.net"
+            }
+        ],
+        "replacementPatterns": [
+            {
+                "pattern": "^.attachments",
+                "replacement": "file://C:\foo\bar\.attachments"
+            }
+        ],
         "httpHeaders": [
             {
                 "urls": [
@@ -147,8 +161,7 @@ If not supplied, the tool reads from standard input.
         ]
     }
 
-`ignorePatterns`: An array of objects holding regular expressions which a link is checked against and skipped for checking in case of a match.
-`httpHeaders`: The headers are only applied to links where the link **starts with** one of the supplied URLs in the `urls` section.
+
 
 ## Testing
 

--- a/index.js
+++ b/index.js
@@ -42,6 +42,13 @@ module.exports = function markdownLinkCheck(markdown, opts, callback) {
             }
         }
 
+        if (opts.replacementPatterns) {
+            for (let replacementPattern of opts.replacementPatterns) {
+                let pattern = replacementPattern.pattern instanceof RegExp ? replacementPattern.pattern : new RegExp(replacementPattern.pattern);
+                link = link.replace(pattern, replacementPattern.replacement);
+            }
+        }
+
         // Make sure it is not undefined and that the appropriate headers are always recalculated for a given link.
         opts.headers = {};
         

--- a/markdown-link-check
+++ b/markdown-link-check
@@ -68,6 +68,7 @@ stream.on('data', function (chunk) {
                     let config = JSON.parse(configData);
 
                     opts.ignorePatterns = config.ignorePatterns;
+                    opts.replacementPatterns = config.replacementPatterns;
                     opts.httpHeaders = config.httpHeaders;
     
                     runMarkdownLinkCheck(markdown, opts);

--- a/test/markdown-link-check.test.js
+++ b/test/markdown-link-check.test.js
@@ -64,7 +64,19 @@ describe('markdown-link-check', function () {
     });
 
     it('should check the links in sample.md', function (done) {
-        markdownLinkCheck(fs.readFileSync(path.join(__dirname, 'sample.md')).toString().replace(/%%BASE_URL%%/g, baseUrl), { baseUrl: baseUrl, ignorePatterns: [{ pattern: /not-working-and-ignored/ }], httpHeaders: [{ urls: [baseUrl + '/basic-auth'], headers: { 'Authorization': 'Basic Zm9vOmJhcg==', 'Foo': 'Bar' }}] }, function (err, results) {
+        markdownLinkCheck(
+            fs.readFileSync(path.join(__dirname, 'sample.md')).toString().replace(/%%BASE_URL%%/g, baseUrl),
+            {
+                baseUrl: baseUrl,
+                ignorePatterns: [{ pattern: /not-working-and-ignored/ }],
+                replacementPatterns: [{ pattern: /boo/, replacement: "foo" }],
+                httpHeaders: [
+                    {
+                        urls: [baseUrl + '/basic-auth'],
+                        headers: { 'Authorization': 'Basic Zm9vOmJhcg==', 'Foo': 'Bar' }
+                    }
+                ] 
+            }, function (err, results) {
             expect(err).to.be(null);
             expect(results).to.be.an('array');
 
@@ -92,6 +104,9 @@ describe('markdown-link-check', function () {
 
                 // ignored
                 { statusCode: 0, status: 'ignored' },
+
+                // replaced
+                { statusCode: 200, status: 'alive' },
 
                 // hello image
                 { statusCode: 200, status: 'alive' },

--- a/test/sample.md
+++ b/test/sample.md
@@ -10,6 +10,7 @@ This is a test file:
 * [redirect](%%BASE_URL%%/foo/redirect) (alive)
 * [basic-auth](%%BASE_URL%%/basic-auth) (alive)
 * [ignored](%%BASE_URL%%/something/not-working-and-ignored/something) (ignored)
+* [replaced](%%BASE_URL%%/boo/bar)
 
 ![img](%%BASE_URL%%/hello.jpg) (alive)
 ![img](hello.jpg) (alive)


### PR DESCRIPTION
I need to support the following two platform specific scenarios (and tried to solve it in a generic way):

1. `[name](.attachments/name.ext)` (also with images)
2. `[name](/some/path/from/root/doc.md)`

We're using the VSTS Wiki and the behavior of the Web UI is to place all uploaded files (including images) into an `.attachments` folder sitting in the root directory.
The 2nd scenario comes into play when you want to reference Markdown documents ("pages") from the Wiki and use the "Copy page path" feature of the Web UI.

Both scenarios can be handled with the proposed solution (e.g. for scenario 2 replacing `"^//"` with the root directory like `file://...`) as well as other potential platform specific conventions.

______________________________________________________

I don't want to make it too complicated for now but would like to mention it: The "Copy page path" thing actually generates `[name](/some/path/from/root/doc)` which is really ugly. I still need to think about this, for example if I would like to have a solution for this as well and if yes - how. For now we will just fix the "dead links" and add the missing `.md`.