### PR TITLE
adds verbose mode for showing detailed error information

### DIFF
--- a/README.md
+++ b/README.md
@@ -123,6 +123,7 @@ If not supplied, the tool reads from standard input.
     -p, --progress         show progress bar
     -c, --config [config]  apply a configuration file (JSON)
     -q, --quiet            display errors only
+    -v, --verbose          displays detailed error information 
     -h, --help             output usage information
 
 ```

--- a/markdown-link-check
+++ b/markdown-link-check
@@ -25,6 +25,7 @@ program
     .option('-p, --progress', 'show progress bar')
     .option('-c, --config [config]', 'apply a config file (JSON), holding e.g. url specific header configuration')
     .option('-q, --quiet', 'displays errors only')
+    .option('-v, --verbose', 'displays detailed error information')
     .arguments('[filenameOrUrl]')
     .action(function (filenameOrUrl) {
     filenameForOutput = filenameOrUrl;
@@ -47,6 +48,7 @@ program
 
 opts.showProgressBar = (program.progress === true); // force true or undefined to be true or false.
 opts.quiet = (program.quiet === true);
+opts.verbose = (program.verbose === true);
 
 let markdown = ''; // collect the markdown data, then process it
 stream.on('data', function (chunk) {
@@ -102,7 +104,16 @@ function runMarkdownLinkCheck(markdown, opts) {
                 return;
             }
 
-            console.log('[%s] %s', statusLabels[result.status], result.link);
+            if (opts.verbose) {
+                if (result.err) {
+                    console.log('[%s] %s → Status: %s %s', statusLabels[result.status], result.link, result.statusCode, result.err);
+                } else {
+                    console.log('[%s] %s → Status: %s', statusLabels[result.status], result.link, result.statusCode);
+                }
+            }
+            else {
+                console.log('[%s] %s', statusLabels[result.status], result.link);
+            }
         });
         if (results.some((result) => result.status === 'dead')) {
             console.error(chalk.red('\nERROR: dead links found!'));


### PR DESCRIPTION
For resolving parts of #35 (showing detailed status and error information)
Sample output:
```
node markdown-link-check -v ../performance.md

FILE: ../performance.md
[✖] ./images/sql-q1uery-reporting.png → Status: 400 Error: ENOENT: no such file or directory, access '/mnt/folder/images/sql-q1uery-reporting.png'
[✓] https://www.google.com → Status: 200
[✓] https://www.microsoft.com → Status: 200
[✖] https://github.com/tcort/markdown-link-check/blob/master/READMEeeeeeeee.md → Status: 404
[✖] https://githuuuuuuuuuuuuuuub.com/tcort/markdown-link-check/blob/master/READMEeeeeeeee.md → Status: 0 Error: getaddrinfo ENOTFOUND githuuuuuuuuuuuuuuub.com githuuuuuuuuuuuuuuub.com:443
[✖] https://giiiiithub.com/tcort/markdown-link-check/blob/master/README.md → Status: 0 Error: getaddrinfo ENOTFOUND giiiiithub.com giiiiithub.com:443
[✖] ./images/sql-query-details.png → Status: 400 Error: ENOENT: no such file or directory, access '/mnt/folder/images/sql-query-details.png'
[✖] api.md#ca1ncelling-the-query → Status: 400 Error: ENOENT: no such file or directory, access '/mnt/folder/api.md'
[✖] README.md#interval-condition → Status: 400 Error: ENOENT: no such file or directory, access '/mnt/folder/README.md'
[✖] README.md#date_format → Status: 400 Error: ENOENT: no such file or directory, access '/mnt/folder/tracks/README.md'
[✖] README.md#extract → Status: 400 Error: ENOENT: no such file or directory, access '/mnt/folder/updates/README.md'

ERROR: dead links found!

```