### PR TITLE
Fix accessing fs.constants.F_OK

### DIFF
--- a/markdown-link-check
+++ b/markdown-link-check
@@ -60,7 +60,7 @@ program
                 process.exit(1);
             }
         });
-        fs.access(filenameOrUrl, fs.constants.F_OK, function(fileerror){
+        fs.access(filenameOrUrl, (fs.constants || fs).F_OK, function(fileerror){
             if (fileerror){
                 console.error(chalk.red('\nERROR: File not found! Please provide a vaild filename as an argument.'));
                 process.exit(1);


### PR DESCRIPTION
Should fix this:
```
TypeError: Cannot read property 'F_OK' of undefined
    at Command.<anonymous> (/usr/local/lib/node_modules/markdown-link-check/markdown-link-check:63:46)
    at Command.listener (/usr/local/lib/node_modules/markdown-link-check/node_modules/commander/index.js:315:8)
    at emitOne (events.js:77:13)
    at Command.emit (events.js:169:7)
    at Command.parseArgs (/usr/local/lib/node_modules/markdown-link-check/node_modules/commander/index.js:653:12)
    at Command.parse (/usr/local/lib/node_modules/markdown-link-check/node_modules/commander/index.js:474:21)
    at Object.<anonymous> (/usr/local/lib/node_modules/markdown-link-check/markdown-link-check:74:4)
    at Module._compile (module.js:409:26)
    at Object.Module._extensions..js (module.js:416:10)
    at Module.load (module.js:343:32)
```