### PR TITLE
fix(typo): fix typos in error messages

### DIFF
--- a/markdown-link-check
+++ b/markdown-link-check
@@ -32,11 +32,11 @@ program
     if (/https?:/.test(filenameOrUrl)) {
         request(filenameOrUrl, function (error, response, body) {
             if (error) {
-                console.error(chalk.red('\nERROR: Unable to connect! Please provide a vaild URL as an argument.'));
+                console.error(chalk.red('\nERROR: Unable to connect! Please provide a valid URL as an argument.'));
                 process.exit(1);
             }
             else if (response.statusCode === 404){
-                console.error(chalk.red('\nERROR: 404 - File not found! Please provide a vaild URL as an argument.'));
+                console.error(chalk.red('\nERROR: 404 - File not found! Please provide a valid URL as an argument.'));
                 process.exit(1);
             } else {
                 stream = request.get(filenameOrUrl);
@@ -51,18 +51,18 @@ program
                 parsed.pathname = parsed.pathname.substr(0, parsed.pathname.lastIndexOf('/') + 1);
             }
             opts.baseUrl = url.format(parsed);
-        } catch (err) { /* ignore error */ 
+        } catch (err) { /* ignore error */
             }
     } else {
         fs.stat(filenameOrUrl, function(error , stats){
             if (stats.isDirectory()){
-                console.error(chalk.red('\nERROR: ' + filenameOrUrl + ' is a directory! Please provide a vaild filename as an argument.'));
+                console.error(chalk.red('\nERROR: ' + filenameOrUrl + ' is a directory! Please provide a valid filename as an argument.'));
                 process.exit(1);
             }
         });
         fs.access(filenameOrUrl, (fs.constants || fs).F_OK, function(fileerror){
             if (fileerror){
-                console.error(chalk.red('\nERROR: File not found! Please provide a vaild filename as an argument.'));
+                console.error(chalk.red('\nERROR: File not found! Please provide a valid filename as an argument.'));
                 process.exit(1);
             } else {
                 opts.baseUrl = 'file://' + path.dirname(path.resolve(filenameOrUrl));
@@ -70,7 +70,7 @@ program
             }
           });
     }
-        
+
 }).parse(process.argv);
 
 opts.showProgressBar = (program.progress === true); // force true or undefined to be true or false.
@@ -90,7 +90,7 @@ stream.on('data', function (chunk) {
             if (!err) {
                 let configStream = fs.createReadStream(program.config);
                 let configData = '';
-                
+
                 configStream.on('data', function (chunk) {
                     configData += chunk.toString();
                 }).on('end', function () {
@@ -99,7 +99,7 @@ stream.on('data', function (chunk) {
                     opts.ignorePatterns = config.ignorePatterns;
                     opts.replacementPatterns = config.replacementPatterns;
                     opts.httpHeaders = config.httpHeaders;
-    
+
                     runMarkdownLinkCheck(markdown, opts);
                 });
             }


### PR DESCRIPTION
This patch fixes several typos in error message were `valid` was `vaild`