### PR TITLE
Switch install from '--save' to '--save-dev'

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ alive (`200 OK`) or dead. `mailto:` links are validated with
 
 To add the module to your project, run:
 
-    npm install --save markdown-link-check
+    npm install --save-dev markdown-link-check
 
 To install the command line tool globally, run:
 


### PR DESCRIPTION
I suspect that the absolute majority of users need this tool only during development.