### PR TITLE
Add support for disable comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ Parameters:
   * `httpHeaders` to apply URL specific headers, see example below.
   * `ignorePatterns` an array of objects holding regular expressions which a link is checked against and skipped for checking in case of a match. Example: `[{ pattern: /foo/ }]`
   * `replacementPatterns` an array of objects holding regular expressions which are replaced in a link with their corresponding replacement string. This behavior allows (for example) to adapt to certain platform conventions hosting the Markdown. Example: `[{ pattern: /^.attachments/, replacement: "file://some/conventional/folder/.attachments" }]`
+  * `ignoreDisable` if this is `true` then disable comments are ignored.
 * `callback` function which accepts `(err, results)`.
   * `err` an Error object when the operation cannot be completed, otherwise `null`.
   * `results` an array of objects with the following properties:
@@ -50,6 +51,15 @@ Parameters:
     * `status` a string set to either `alive`, `ignored` or `dead`.
     * `statusCode` the HTTP status code. Set to `0` if no HTTP status code was returned (e.g. when the server is down).
     * `err` any connection error that occurred, otherwise `null`.
+
+#### Disable comments
+
+You can write html comments to disable markdown-link-check for parts of the text.
+
+`<!-- markdown-link-check-disable -->` disables markdown link check.
+`<!-- markdown-link-check-enable -->` reenables markdown link check.
+`<!-- markdown-link-check-disable-next-line -->` disables markdown link check for the next line.
+`<!-- markdown-link-check-disable-line -->` disables markdown link check for this line.
 
 ## Examples
 

--- a/index.js
+++ b/index.js
@@ -14,6 +14,15 @@ module.exports = function markdownLinkCheck(markdown, opts, callback) {
         opts = {};
     }
 
+    markdown = [
+        /(<!--[ \t]+markdown-link-check-disable[ \t]+-->[\S\s]*?<!--[ \t]+markdown-link-check-enable[ \t]+-->)/mg,
+        /(<!--[ \t]+markdown-link-check-disable[ \t]+-->[\S\s]*(?!<!--[ \t]+markdown-link-check-enable[ \t]+-->))/mg,
+        /(<!--[ \t]+markdown-link-check-disable-next-line[ \t]+-->\r?\n[^\r\n]*)/mg,
+        /([^\r\n]*<!--[ \t]+markdown-link-check-disable-line[ \t]+-->[^\r\n]*)/mg
+    ].reduce(function(_markdown, disablePattern) {
+        return _markdown.replace(new RegExp(disablePattern), '');
+    }, markdown);
+    
     const linksCollection = _.uniq(markdownLinkExtractor(markdown));
     const bar = (opts.showProgressBar) ?
         new ProgressBar('Checking... [:bar] :percent', {

--- a/index.js
+++ b/index.js
@@ -14,15 +14,18 @@ module.exports = function markdownLinkCheck(markdown, opts, callback) {
         opts = {};
     }
 
-    markdown = [
-        /(<!--[ \t]+markdown-link-check-disable[ \t]+-->[\S\s]*?<!--[ \t]+markdown-link-check-enable[ \t]+-->)/mg,
-        /(<!--[ \t]+markdown-link-check-disable[ \t]+-->[\S\s]*(?!<!--[ \t]+markdown-link-check-enable[ \t]+-->))/mg,
-        /(<!--[ \t]+markdown-link-check-disable-next-line[ \t]+-->\r?\n[^\r\n]*)/mg,
-        /([^\r\n]*<!--[ \t]+markdown-link-check-disable-line[ \t]+-->[^\r\n]*)/mg
-    ].reduce(function(_markdown, disablePattern) {
-        return _markdown.replace(new RegExp(disablePattern), '');
-    }, markdown);
+    if(!opts.ignoreDisable) {
+        markdown = [
+            /(<!--[ \t]+markdown-link-check-disable[ \t]+-->[\S\s]*?<!--[ \t]+markdown-link-check-enable[ \t]+-->)/mg,
+            /(<!--[ \t]+markdown-link-check-disable[ \t]+-->[\S\s]*(?!<!--[ \t]+markdown-link-check-enable[ \t]+-->))/mg,
+            /(<!--[ \t]+markdown-link-check-disable-next-line[ \t]+-->\r?\n[^\r\n]*)/mg,
+            /([^\r\n]*<!--[ \t]+markdown-link-check-disable-line[ \t]+-->[^\r\n]*)/mg
+        ].reduce(function(_markdown, disablePattern) {
+            return _markdown.replace(new RegExp(disablePattern), '');
+        }, markdown);
+    }
     
+    console.log(markdown);
     const linksCollection = _.uniq(markdownLinkExtractor(markdown));
     const bar = (opts.showProgressBar) ?
         new ProgressBar('Checking... [:bar] :percent', {

--- a/markdown-link-check
+++ b/markdown-link-check
@@ -103,6 +103,7 @@ stream
                     opts.ignorePatterns = config.ignorePatterns;
                     opts.replacementPatterns = config.replacementPatterns;
                     opts.httpHeaders = config.httpHeaders;
+                    opts.ignoreDisable = config.ignoreDisable;
 
                     runMarkdownLinkCheck(markdown, opts);
                 });

--- a/package-lock.json
+++ b/package-lock.json
@@ -121,7 +121,7 @@
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
       "dev": true,
       "requires": {
-        "balanced-match": "1.0.0",
+        "balanced-match": "^1.0.0",
         "concat-map": "0.0.1"
       }
     },
@@ -516,12 +516,12 @@
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
       "dev": true,
       "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
       }
     },
     "growl": {
@@ -606,8 +606,8 @@
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
       "dev": true,
       "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
+        "once": "^1.3.0",
+        "wrappy": "1"
       }
     },
     "inherits": {
@@ -778,7 +778,7 @@
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
       "dev": true,
       "requires": {
-        "brace-expansion": "1.1.11"
+        "brace-expansion": "^1.1.7"
       }
     },
     "minimist": {
@@ -869,7 +869,7 @@
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
       "dev": true,
       "requires": {
-        "wrappy": "1.0.2"
+        "wrappy": "1"
       }
     },
     "parseurl": {
@@ -1076,7 +1076,7 @@
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.4.0.tgz",
       "integrity": "sha512-zjaXglF5nnWpsq470jSv6P9DwPvgLkuapYmfDm3JWOm0vkNTVF2tI4UrN2r6jH1qM/uc/WtxYY1hYoA2dOKj5w==",
       "requires": {
-        "has-flag": "3.0.0"
+        "has-flag": "^3.0.0"
       }
     },
     "toidentifier": {

--- a/test/file.md
+++ b/test/file.md
@@ -5,3 +5,12 @@ This is a test file:
 ![img](%%BASE_URL%%/hello.jpg) (alive)
 ![img](hello.jpg) (alive)
 ![img](goodbye.jpg) (dead)
+
+<!-- markdown-link-check-disable -->
+![img](goodbye.jpg) (dead)
+<!-- markdown-link-check-enable -->
+<!-- markdown-link-check-disable-next-line -->
+![img](goodbye.jpg) (dead)
+![img](goodbye.jpg) (dead) <!-- markdown-link-check-disable-line -->
+<!-- markdown-link-check-disable -->
+![img](goodbye.jpg) (dead)


### PR DESCRIPTION
Adds support for disable comments (similar to the ones in eslint).

`<!-- markdown-link-check-disable -->` disables markdown link check.
`<!-- markdown-link-check-enable -->` reenables markdown link check.
`<!-- markdown-link-check-disable-next-line -->` disables markdown link check for the next line.
`<!-- markdown-link-check-disable-line -->` disables markdown link check for this line.

The parameter ignoreDisable was added to ignore disable comments.