### PR TITLE
Remove unnecessary files in the package published to npmjs

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,9 @@
     "url": "https://github.com/tcort/markdown-link-check/issues"
   },
   "homepage": "https://github.com/tcort/markdown-link-check#readme",
+  "files": [
+    "markdown-link-check"
+  ],
   "dependencies": {
     "async": "^3.1.0",
     "chalk": "^2.4.2",


### PR DESCRIPTION
Hi,

First, thanks for your work! 
I've made a fix to remove unnecessary files from the published package on [npmjs](https://www.npmjs.com/).

- Here is the content of the published package before the fix (`npm pack --dry-run`):

```
npm notice
npm notice 📦  markdown-link-check@3.8.0
npm notice === Tarball Contents ===
npm notice 272B   Dockerfile
npm notice 5.9kB  markdown-link-check
npm notice 19.2kB test/hello.jpg
npm notice 3.5kB  index.js
npm notice 6.2kB  test/markdown-link-check.test.js
npm notice 1.8kB  package.json
npm notice 1.4kB  CHANGELOG.md
npm notice 248B   CONTRIBUTING.md
npm notice 432B   test/file.md
npm notice 766B   LICENSE.md
npm notice 5.8kB  README.md
npm notice 780B   test/sample.md
npm notice 57B    .travis.yml
npm notice === Tarball Details ===
npm notice name:          markdown-link-check
npm notice version:       3.8.0
npm notice filename:      markdown-link-check-3.8.0.tgz
npm notice package size:  26.2 kB
npm notice unpacked size: 46.3 kB
npm notice shasum:        0ea5103d9cc329f809e326d7efb2c85cf8ddab16
npm notice integrity:     sha512-Wv9GJQ4NTRIWz[...]JAyqqcqQAculg==
npm notice total files:   13
```

- Here is the content of the published package after my fix:

```
npm notice
npm notice 📦  markdown-link-check@3.8.0
npm notice === Tarball Contents ===
npm notice 5.9kB markdown-link-check
npm notice 3.5kB index.js
npm notice 1.8kB package.json
npm notice 1.4kB CHANGELOG.md
npm notice 766B  LICENSE.md
npm notice 5.8kB README.md
npm notice === Tarball Details ===
npm notice name:          markdown-link-check
npm notice version:       3.8.0
npm notice filename:      markdown-link-check-3.8.0.tgz
npm notice package size:  6.2 kB
npm notice unpacked size: 19.1 kB
npm notice shasum:        52b8e286a5f5d51d8fbc9f170c06c8c90959dda9
npm notice integrity:     sha512-YcpIxApC3voQl[...]7UXmUPtjAht2w==
npm notice total files:   6
```