### PR TITLE
Make http 429 and 206 codes return `alive`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,9 @@ Parameters:
   * `ignorePatterns` an array of objects holding regular expressions which a link is checked against and skipped for checking in case of a match. Example: `[{ pattern: /foo/ }]`
   * `replacementPatterns` an array of objects holding regular expressions which are replaced in a link with their corresponding replacement string. This behavior allows (for example) to adapt to certain platform conventions hosting the Markdown. Example: `[{ pattern: /^.attachments/, replacement: "file://some/conventional/folder/.attachments" }]`
   * `ignoreDisable` if this is `true` then disable comments are ignored.
+  * `retryOn429` if this is `true` then retry request when response is an HTTP code 429 and retry within the delay indicated by `retry-after` header.
+  * `aliveStatusCodes` a list of HTTP codes to consider as alive.
+    Example: `[200,206]`
 * `callback` function which accepts `(err, results)`.
   * `err` an Error object when the operation cannot be completed, otherwise `null`.
   * `results` an array of objects with the following properties:
@@ -129,17 +132,16 @@ If not supplied, the tool reads from standard input.
 #### Usage
 
 ```
+Usage: markdown-link-check [options] [filenameOrUrl]
 
-  Usage: markdown-link-check [options] [filenameOrUrl]
-
-  Options:
-
-    -p, --progress         show progress bar
-    -c, --config [config]  apply a configuration file (JSON)
-    -q, --quiet            display errors only
-    -v, --verbose          displays detailed error information 
-    -h, --help             output usage information
-
+Options:
+  -p, --progress         show progress bar
+  -c, --config [config]  apply a config file (JSON), holding e.g. url specific header configuration
+  -q, --quiet            displays errors only
+  -v, --verbose          displays detailed error information
+  -a, --alive <code>     comma separated list of HTTP code to be considered as alive
+  -r, --retry            retry after the duration indicated in 'retry-after' header when HTTP code is 429
+  -h, --help             display help for command
 ```
 
 ##### Config file format
@@ -149,6 +151,8 @@ If not supplied, the tool reads from standard input.
 * `ignorePatterns`: An array of objects holding regular expressions which a link is checked against and skipped for checking in case of a match.
 * `replacementPatterns`: An array of objects holding regular expressions which are replaced in a link with their corresponding replacement string. This behavior allows (for example) to adapt to certain platform conventions hosting the Markdown.
 * `httpHeaders`: The headers are only applied to links where the link **starts with** one of the supplied URLs in the `urls` section.
+* `retryOn429` if this is `true` then retry request when response is an HTTP code 429 and retry within the delay indicated by `retry-after` header.
+* `aliveStatusCodes` a list of HTTP codes to consider as alive.
 
 **Example:**
 
@@ -175,7 +179,9 @@ If not supplied, the tool reads from standard input.
 				"Foo": "Bar"
 			}
 		}
-	]
+	],
+  "retryOn429":true,
+  "aliveStatusCodes":[200, 206]
 }
 ```
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Parameters:
   * `ignorePatterns` an array of objects holding regular expressions which a link is checked against and skipped for checking in case of a match. Example: `[{ pattern: /foo/ }]`
   * `replacementPatterns` an array of objects holding regular expressions which are replaced in a link with their corresponding replacement string. This behavior allows (for example) to adapt to certain platform conventions hosting the Markdown. Example: `[{ pattern: /^.attachments/, replacement: "file://some/conventional/folder/.attachments" }]`
   * `ignoreDisable` if this is `true` then disable comments are ignored.
-  * `retryOn429` if this is `true` then retry request when response is an HTTP code 429 and retry within the delay indicated by `retry-after` header.
+  * `retryOn429` if this is `true` then retry request when response is an HTTP code 429 after the duration indicated by `retry-after` header.
   * `aliveStatusCodes` a list of HTTP codes to consider as alive.
     Example: `[200,206]`
 * `callback` function which accepts `(err, results)`.
@@ -151,7 +151,7 @@ Options:
 * `ignorePatterns`: An array of objects holding regular expressions which a link is checked against and skipped for checking in case of a match.
 * `replacementPatterns`: An array of objects holding regular expressions which are replaced in a link with their corresponding replacement string. This behavior allows (for example) to adapt to certain platform conventions hosting the Markdown.
 * `httpHeaders`: The headers are only applied to links where the link **starts with** one of the supplied URLs in the `urls` section.
-* `retryOn429` if this is `true` then retry request when response is an HTTP code 429 and retry within the delay indicated by `retry-after` header.
+* `retryOn429` if this is `true` then retry request when response is an HTTP code 429 after the duration indicated by `retry-after` header.
 * `aliveStatusCodes` a list of HTTP codes to consider as alive.
 
 **Example:**

--- a/index.js
+++ b/index.js
@@ -71,9 +71,6 @@ module.exports = function markdownLinkCheck(markdown, opts, callback) {
             }
         }
 
-        opts.retryOn429 = true;
-        opts.aliveStatusCodes = [200,206];
-
         linkCheck(link, opts, function (err, result) {
 
             if (opts.showProgressBar) {

--- a/index.js
+++ b/index.js
@@ -71,7 +71,11 @@ module.exports = function markdownLinkCheck(markdown, opts, callback) {
             }
         }
 
+        opts.retryOn429 = true;
+        opts.aliveStatusCodes = [200,206];
+
         linkCheck(link, opts, function (err, result) {
+
             if (opts.showProgressBar) {
                 bar.tick();
             }

--- a/markdown-link-check
+++ b/markdown-link-check
@@ -21,11 +21,17 @@ const opts = {};
 let filenameForOutput = '';
 let stream = process.stdin; // read from stdin unless a filename is given
 
+function commaSeparatedList(value, dummyPrevious) {
+  return value.split(',');
+}
+
 program
     .option('-p, --progress', 'show progress bar')
     .option('-c, --config [config]', 'apply a config file (JSON), holding e.g. url specific header configuration')
     .option('-q, --quiet', 'displays errors only')
     .option('-v, --verbose', 'displays detailed error information')
+    .option('-a, --alive <HTTP code>', 'comma separated list of HTTP code to be considerered as alive', commaSeparatedList)
+    .option('-r, --retry', 'retry after the duration indicated in \'retry-after\' header when HTTP code is 429')
     .arguments('[filenameOrUrl]')
     .action(function (filenameOrUrl) {
     filenameForOutput = filenameOrUrl;
@@ -69,6 +75,8 @@ program
 opts.showProgressBar = (program.progress === true); // force true or undefined to be true or false.
 opts.quiet = (program.quiet === true);
 opts.verbose = (program.verbose === true);
+opts.retryOn429 = (program.retry === true);
+opts.aliveStatusCodes = program.alive;
 
 let markdown = ''; // collect the markdown data, then process it
 

--- a/markdown-link-check
+++ b/markdown-link-check
@@ -112,6 +112,8 @@ stream
                     opts.replacementPatterns = config.replacementPatterns;
                     opts.httpHeaders = config.httpHeaders;
                     opts.ignoreDisable = config.ignoreDisable;
+                    opts.retryOn429 = config.retryOn429;
+                    opts.aliveStatusCodes = config.aliveStatusCodes;
 
                     runMarkdownLinkCheck(markdown, opts);
                 });

--- a/markdown-link-check
+++ b/markdown-link-check
@@ -21,8 +21,10 @@ const opts = {};
 let filenameForOutput = '';
 let stream = process.stdin; // read from stdin unless a filename is given
 
-function commaSeparatedList(value, dummyPrevious) {
-  return value.split(',');
+function commaSeparatedCodesList(value, dummyPrevious) {
+    return value.split(',').map(function(item) {
+      return parseInt(item, 10);
+    });
 }
 
 program
@@ -30,7 +32,7 @@ program
     .option('-c, --config [config]', 'apply a config file (JSON), holding e.g. url specific header configuration')
     .option('-q, --quiet', 'displays errors only')
     .option('-v, --verbose', 'displays detailed error information')
-    .option('-a, --alive <HTTP code>', 'comma separated list of HTTP code to be considerered as alive', commaSeparatedList)
+    .option('-a, --alive <code>', 'comma separated list of HTTP codes to be considered as alive', commaSeparatedCodesList)
     .option('-r, --retry', 'retry after the duration indicated in \'retry-after\' header when HTTP code is 429')
     .arguments('[filenameOrUrl]')
     .action(function (filenameOrUrl) {

--- a/test/markdown-link-check.test.js
+++ b/test/markdown-link-check.test.js
@@ -82,7 +82,7 @@ describe('markdown-link-check', function () {
             done();
         });
     });
-    
+
     it('should check the links in sample.md', function (done) {
         markdownLinkCheck(
             fs.readFileSync(path.join(__dirname, 'sample.md')).toString().replace(/%%BASE_URL%%/g, baseUrl),
@@ -95,7 +95,9 @@ describe('markdown-link-check', function () {
                         urls: [baseUrl + '/basic-auth'],
                         headers: { 'Authorization': 'Basic Zm9vOmJhcg==', 'Foo': 'Bar' }
                     }
-                ]
+                ],
+                "aliveStatusCodes":[200, 206],
+                "retryOn429":true
             }, function (err, results) {
             expect(err).to.be(null);
             expect(results).to.be.an('array');

--- a/test/sample.md
+++ b/test/sample.md
@@ -11,6 +11,8 @@ This is a test file:
 * [basic-auth](%%BASE_URL%%/basic-auth) (alive)
 * [ignored](%%BASE_URL%%/something/not-working-and-ignored/something) (ignored)
 * [replaced](%%BASE_URL%%/boo/bar)
+* [later](%%BASE_URL%%/later)
+* [partial](%%BASE_URL%%/partial)
 
 ![img](%%BASE_URL%%/hello.jpg) (alive)
 ![img](hello.jpg) (alive)


### PR DESCRIPTION
## Added features

- http 429 code retry option.
   The link-check library used to check links here have this option but it defaults to disabled. I added a CLI option (`-r` or `--retry`) and also the ability to add the option to the JSON config file.
- option to define the http codes for which an `alive` status is returned. I did not only make 206 work, but any code and it's configurable. Default is 200 only.
   CLI option and JSON config options are available. In JSON the list of codes has to be an integer array, on the command line a list with values separated by commas.

## Testing

- test suite was updated to check for 206codes to be considered alive and for retry on 429 with a duration returned by headers. 
- no CLI test are already present in the library so I did not add any. Maybe a TODO...

## Doc

- CLI help updated
- README updated

## Related issues

- Fixes my own issues
- fixes #101 
- fixes #94 