### PR TITLE
Add Docker build and Release workflows via Github workflows

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,56 @@
+name: Docker
+
+on:
+  pull_request:
+    paths-ignore:
+      - '.**'
+  push:
+    paths-ignore:
+      - '.**'
+
+defaults:
+  run:
+    shell: bash
+
+jobs:
+  build-and-publish:
+    name: Build & Publish
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Config: Registry"
+        run: echo ::set-env name=REGISTRY::ghcr.io
+      - name: "Config: Image Name"
+        run: echo ::set-env name=IMAGE_NAME::${{ github.repository_owner }}/$(basename ${{ github.repository }})
+      - name: "Config: Image URL"
+        run: echo ::set-env name=IMAGE_URL::${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+      - name: "Repo: Checkout"
+        uses: actions/checkout@v2
+      - name: "Docker: Build & Publish"
+        id: build
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: ${{ env.IMAGE_NAME }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.PUBLISH_TOKEN }}
+          snapshot: true
+      - name: "Config: Full Image URL"
+        run: echo ::set-env name=FULL_SNAPSHOT_URL::${{ env.IMAGE_URL }}:${{ steps.build.outputs.snapshot-tag }}
+      - name: "Feedback: Commit Comment"
+        uses: peter-evans/commit-comment@v1
+        with:
+          body: |
+           :tada: **Docker testing image published**
+
+           **URL:** `${{ env.FULL_SNAPSHOT_URL }}`
+
+           To use the image:
+           ```
+           docker pull ${{ env.FULL_SNAPSHOT_URL }}
+           ```
+
+           Additionally, the most recent build for this branch is tagged `${{ steps.build.outputs.tag }}`, to use it:
+
+            ```
+           docker pull ${{ env.IMAGE_URL }}:${{ steps.build.outputs.tag }}
+           ```

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,37 @@
+name: Release
+
+on:
+  release:
+    types: created
+
+jobs:
+  docker-build-and-publish:
+    name: "Docker: Build & Publish"
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Config: Registry"
+        run: echo ::set-env name=REGISTRY::ghcr.io
+      - name: "Config: Image Name"
+        run: echo ::set-env name=IMAGE_NAME::${{ github.repository_owner }}/$(basename ${{ github.repository }})
+      - name: "Config: Image URL"
+        run: echo ::set-env name=IMAGE_URL::${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        # Derriving semver tags this way is hacky, but the action doesn't seem to think you would want to set
+        # both latest AND semver...
+      - name: "Config: Semver Tags"
+        run: |
+          echo ::set-env name=SEMVER_TAGS::$(echo ${{ github.ref }} \
+          | sed -e "s/refs\/tags\///g" \
+          | sed -E "s/v?([0-9]+)\.([0-9]+)\.([0-9]+)(-[a-zA-Z]+(\.[0-9]+)?)?/\1.\2.\3\4\,\1.\2\4\,\1\4/g")
+      - name: "Repo: Checkout"
+        uses: actions/checkout@v2
+      - name: "Docker: Build & Publish"
+        id: build
+        uses: elgohr/Publish-Docker-Github-Action@master
+        with:
+          name: ${{ env.IMAGE_NAME }}
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.PUBLISH_TOKEN }}
+          tags: latest,stable,${{ env.SEMVER_TAGS }}
+      - name: "Config: Full Image URL"
+        run: echo ::set-env name=FULL_SNAPSHOT_URL::${{ env.IMAGE_URL }}:${{ steps.build.outputs.tag }}


### PR DESCRIPTION
Addresses Docker Image portion of #110.

* Create Docker workflow that builds images on each push/pull request and comments on commits with link
* Build and tag docker images on a new release (tagged latest, stable, semver)

## Implementation
The workflows associated with this PR use the GitHub Container Registry (GitHub Package Docker Registry will sunset next year). GCR requires a Personal Access Token with the `package:write` permission to push images.

The workflows use the PAT in form of a secret called `PUBLISH_TOKEN`. **Prior to merge**, a PAT with `package:write` should be created and stored in the repository secrets as `PUBLISH_TOKEN`.

[Creating a personal access token - GitHub Docs](https://docs.github.com/en/free-pro-team@latest/github/authenticating-to-github/creating-a-personal-access-token)
[Encrypted secrets - GitHub Docs](https://docs.github.com/en/free-pro-team@latest/actions/reference/encrypted-secrets#creating-encrypted-secrets-for-a-repository)

Once the first image is pushed to GHCR, it will need to be marked public (otherwise credentials are required for pull).

[Configuring visibility of container images for your personal account](https://docs.github.com/en/free-pro-team@latest/packages/managing-container-images-with-github-container-registry/configuring-access-control-and-visibility-for-container-images#configuring-visibility-of-container-images-for-your-personal-account)