### PR TITLE
Update Dockerfile to ready image for public distribution

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,16 @@
-FROM node:latest
-LABEL maintainer="https://github.com/4x0v7"
+FROM node:alpine
+
+# Use the Open Container Image Annotation Spec (https://github.com/opencontainers/image-spec/blob/master/annotations.md)
+LABEL org.opencontainers.image.title="markdown-link-check"
+LABEL org.opencontainers.image.description="checks that all hyperlinks in a markdown text to determine if they are alive or dead"
+LABEL org.opencontainers.image.documentation="https://github.com/tcort/markdown-link-check/blob/master/README.md"
+LABEL org.opencontainers.image.source="https://github.com/tcort/markdown-link-check"
 
 # Install app dependencies
-COPY package.json /src/package.json
+COPY package*.json /src/
 WORKDIR /src
 RUN set -ex; \
-    npm install \
-    && npm ls
+    npm install
 # Bundle app source
 COPY . /src
 RUN npm test


### PR DESCRIPTION
Related to #110, but general image clean up.

* Use `node:alpine` image; the previous image `node:latest` is quite large (973 M) and provides no benefit above `node:alpine` (143 MB) for repo purposes.
* Transition to [Open Container Image Annotation spec](https://github.com/opencontainers/image-spec/blob/master/annotations.md) for image labels.
* Copy `package-lock.json` into environment.
* Remove `npm ls` from build as it clutters output and doesn't provide direct benefit.

### Caveats

* Image debugging is easier with:
```
docker run --rm -it --entrypoint /bin/sh <image>
```

* Additional labels (version, created) should be added at build time.