### PR TITLE
update link-check dependency to 4.5.2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1144,9 +1144,9 @@
       }
     },
     "link-check": {
-      "version": "4.5.1",
-      "resolved": "https://registry.npmjs.org/link-check/-/link-check-4.5.1.tgz",
-      "integrity": "sha512-g0tu3Nkj/rpl1b6rQHRlaaSZ16iRqRDNP30jLUfRK0uNN98H56YVZlJXLjWcyjsj4f2+xZdxqeV398dx38MzfQ==",
+      "version": "4.5.2",
+      "resolved": "https://registry.npmjs.org/link-check/-/link-check-4.5.2.tgz",
+      "integrity": "sha512-I5dWK5rl2wq7nYRBrx8kDjp2roXqa6jdHcKTPBkh9/UlhwToAgCMIRdeUGKxichESo9BpHafF1ao+B8Ek6ErJg==",
       "requires": {
         "is-relative-url": "^3.0.0",
         "isemail": "^3.2.0",

--- a/package.json
+++ b/package.json
@@ -36,11 +36,11 @@
     "async": "^3.2.0",
     "chalk": "^4.1.0",
     "commander": "^6.1.0",
-    "link-check": "^4.5.1",
-    "markdown-link-extractor": "^1.2.6",
-    "request": "^2.88.2",
+    "link-check": "^4.5.2",
     "lodash": "^4.17.20",
-    "progress": "^2.0.3"
+    "markdown-link-extractor": "^1.2.6",
+    "progress": "^2.0.3",
+    "request": "^2.88.2"
   },
   "devDependencies": {
     "expect.js": "^0.3.1",


### PR DESCRIPTION
fixes related to handling of 429 HTTP errors
fixes #114