### PR TITLE
Switch to the new Github Actions environment variable idiom

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -18,11 +18,11 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Config: Registry"
-        run: echo ::set-env name=REGISTRY::ghcr.io
+        run: echo "REGISTRY=ghcr.io" >> $GITHUB_ENV
       - name: "Config: Image Name"
-        run: echo ::set-env name=IMAGE_NAME::${{ github.repository_owner }}/$(basename ${{ github.repository }})
+        run: echo "IMAGE_NAME=${{ github.repository_owner }}/$(basename ${{ github.repository }})" >> $GITHUB_ENV
       - name: "Config: Image URL"
-        run: echo ::set-env name=IMAGE_URL::${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        run: echo "IMAGE_URL=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
       - name: "Repo: Checkout"
         uses: actions/checkout@v2
       - name: "Docker: Build & Publish"
@@ -35,7 +35,7 @@ jobs:
           password: ${{ secrets.PUBLISH_TOKEN }}
           snapshot: true
       - name: "Config: Full Image URL"
-        run: echo ::set-env name=FULL_SNAPSHOT_URL::${{ env.IMAGE_URL }}:${{ steps.build.outputs.snapshot-tag }}
+        run: echo "FULL_SNAPSHOT_URL=${{ env.IMAGE_URL }}:${{ steps.build.outputs.snapshot-tag }}" >> $GITHUB_ENV
       - name: "Feedback: Commit Comment"
         uses: peter-evans/commit-comment@v1
         with:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,18 +10,18 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: "Config: Registry"
-        run: echo ::set-env name=REGISTRY::ghcr.io
+        run: echo "REGISTRY=ghcr.io" >> $GITHUB_ENV
       - name: "Config: Image Name"
-        run: echo ::set-env name=IMAGE_NAME::${{ github.repository_owner }}/$(basename ${{ github.repository }})
+        run: echo "IMAGE_NAME=${{ github.repository_owner }}/$(basename ${{ github.repository }})" >> $GITHUB_ENV
       - name: "Config: Image URL"
-        run: echo ::set-env name=IMAGE_URL::${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+        run: echo "IMAGE_URL=${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}" >> $GITHUB_ENV
         # Derriving semver tags this way is hacky, but the action doesn't seem to think you would want to set
         # both latest AND semver...
       - name: "Config: Semver Tags"
         run: |
-          echo ::set-env name=SEMVER_TAGS::$(echo ${{ github.ref }} \
-          | sed -e "s/refs\/tags\///g" \
-          | sed -E "s/v?([0-9]+)\.([0-9]+)\.([0-9]+)(-[a-zA-Z]+(\.[0-9]+)?)?/\1.\2.\3\4\,\1.\2\4\,\1\4/g")
+          echo "SEMVER_TAGS::$(echo ${{ github.ref }} \
+          | sed -e 's/refs\/tags\///g' \
+          | sed -E 's/v?([0-9]+)\.([0-9]+)\.([0-9]+)(-[a-zA-Z]+(\.[0-9]+)?)?/\1.\2.\3\4\,\1.\2\4\,\1\4/g')" $GITHUB_ENV
       - name: "Repo: Checkout"
         uses: actions/checkout@v2
       - name: "Docker: Build & Publish"


### PR DESCRIPTION
Old mode deprecated for security reasons (https://github.blog/changelog/2020-10-01-github-actions-deprecating-set-env-and-add-path-commands/)