### PR TITLE
add {{BASEURL}} as replacement pattern

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,7 +59,8 @@ Parameters:
   * `timeout` timeout in [zeit/ms](https://www.npmjs.com/package/ms) format. (e.g. `"2000ms"`, `20s`, `1m`). Default `10s`.
   * `httpHeaders` to apply URL specific headers, see example below.
   * `ignorePatterns` an array of objects holding regular expressions which a link is checked against and skipped for checking in case of a match. Example: `[{ pattern: /foo/ }]`
-  * `replacementPatterns` an array of objects holding regular expressions which are replaced in a link with their corresponding replacement string. This behavior allows (for example) to adapt to certain platform conventions hosting the Markdown. Example: `[{ pattern: /^.attachments/, replacement: "file://some/conventional/folder/.attachments" }]`
+  * `replacementPatterns` an array of objects holding regular expressions which are replaced in a link with their corresponding replacement string. This behavior allows (for example) to adapt to certain platform conventions hosting the Markdown. The special replacement `{{BASEURL}}` can be used to dynamically link to the base folder (used from `projectBaseUrl`) (for example that `/` points to the root of your local repository). Example: `[{ pattern: /^.attachments/, replacement: "file://some/conventional/folder/.attachments" }, { pattern: ^/, replacement: "{{BASEURL}}/"}]`
+  * `projectBaseUrl` the URL to use for `{{BASEURL}}` replacement
   * `ignoreDisable` if this is `true` then disable comments are ignored.
   * `retryOn429` if this is `true` then retry request when response is an HTTP code 429 after the duration indicated by `retry-after` header.
   * `retryCount` the number of retries to be made on a 429 response. Default `2`.
@@ -166,7 +167,7 @@ Options:
 `config.json`:
 
 * `ignorePatterns`: An array of objects holding regular expressions which a link is checked against and skipped for checking in case of a match.
-* `replacementPatterns`: An array of objects holding regular expressions which are replaced in a link with their corresponding replacement string. This behavior allows (for example) to adapt to certain platform conventions hosting the Markdown.
+* `replacementPatterns`: An array of objects holding regular expressions which are replaced in a link with their corresponding replacement string. This behavior allows (for example) to adapt to certain platform conventions hosting the Markdown. The special replacement `{{BASEURL}}` can be used to dynamically link to the current working directory (for example that `/` points to the root of your current working directory).
 * `httpHeaders`: The headers are only applied to links where the link **starts with** one of the supplied URLs in the `urls` section.
 * `timeout` timeout in [zeit/ms](https://www.npmjs.com/package/ms) format. (e.g. `"2000ms"`, `20s`, `1m`). Default `10s`.
 * `retryOn429` if this is `true` then retry request when response is an HTTP code 429 after the duration indicated by `retry-after` header.
@@ -187,6 +188,10 @@ Options:
     {
       "pattern": "^.attachments",
       "replacement": "file://some/conventional/folder/.attachments"
+    },
+    {
+      "pattern": "^/",
+      "replacement": "{{BASEURL}}/"
     }
   ],
   "httpHeaders": [

--- a/index.js
+++ b/index.js
@@ -51,7 +51,9 @@ module.exports = function markdownLinkCheck(markdown, opts, callback) {
         if (opts.replacementPatterns) {
             for (let replacementPattern of opts.replacementPatterns) {
                 let pattern = replacementPattern.pattern instanceof RegExp ? replacementPattern.pattern : new RegExp(replacementPattern.pattern);
-                link = link.replace(pattern, replacementPattern.replacement);
+                // replace the `{{BASEURL}}` with the opts.projectBaseUrl. Helpful to build absolute urls "relative" to project roots
+                const replacement = replacementPattern.replacement.replace('{{BASEURL}}', opts.projectBaseUrl);
+                link = link.replace(pattern, replacement);
             }
         }
 

--- a/markdown-link-check
+++ b/markdown-link-check
@@ -79,6 +79,8 @@ opts.quiet = (program.quiet === true);
 opts.verbose = (program.verbose === true);
 opts.retryOn429 = (program.retry === true);
 opts.aliveStatusCodes = program.alive;
+// set the projectBaseUrl to the current working directory, so that `{{BASEURL}}` can be resolved to the project root.
+opts.projectBaseUrl = `file://${process.cwd()}`;
 
 let markdown = ''; // collect the markdown data, then process it
 

--- a/test/local-file.md
+++ b/test/local-file.md
@@ -1,0 +1,21 @@
+# Sample
+
+This is a test file leveraging the local replacement patterns `{{BASEURL}}` for `/`:
+
+![img](/test/hello.jpg) (alive)
+![img](%%BASE_URL%%/hello.jpg) (alive)
+![img](hello.jpg) (alive)
+![img](./hello.jpg) (alive)
+![img](/test/goodbye.jpg) (dead)
+![img](/hello.jpg) (dead)
+
+
+
+<!-- markdown-link-check-disable -->
+![img](goodbye.jpg) (dead)
+<!-- markdown-link-check-enable -->
+<!-- markdown-link-check-disable-next-line -->
+![img](goodbye.jpg) (dead)
+![img](goodbye.jpg) (dead) <!-- markdown-link-check-disable-line -->
+<!-- markdown-link-check-disable -->
+![img](goodbye.jpg) (dead)

--- a/test/markdown-link-check.test.js
+++ b/test/markdown-link-check.test.js
@@ -192,6 +192,31 @@ describe('markdown-link-check', function () {
         });
     });
 
+    it('should check the links in local-file.md', function (done) {
+        markdownLinkCheck(fs.readFileSync(path.join(__dirname, 'local-file.md')).toString().replace(/%%BASE_URL%%/g, 'file://' + __dirname), {baseUrl: 'file://' + __dirname, projectBaseUrl: 'file://' + __dirname + "/..",replacementPatterns: [{ pattern: '^/', replacement: "{{BASEURL}}/"}]}, function (err, results) {
+            expect(err).to.be(null);
+            expect(results).to.be.an('array');
+
+            const expected = [
+                { statusCode: 200, status: 'alive' },
+                { statusCode: 200, status: 'alive' },
+                { statusCode: 200, status: 'alive' },
+                { statusCode: 200, status: 'alive' },
+                { statusCode: 400, status:  'dead' },
+                { statusCode: 400, status:  'dead' },
+            ];
+
+            expect(results.length).to.be(expected.length);
+
+            for (let i = 0; i < results.length; i++) {
+                expect(results[i].statusCode).to.be(expected[i].statusCode);
+                expect(results[i].status).to.be(expected[i].status);
+            }
+
+            done();
+        });
+    });
+
     it('should handle thousands of links (this test takes up to a minute)', function (done) {
         this.timeout(60000);
 


### PR DESCRIPTION
This PR allows to use `{{BASEURL}}` as a variable in the replacement patterns to be replaced during execution with the `opts.baseUrl`. This allows to write generic config files, which work also for local reference checks of URL. 

For example following config can be now used to check that all urls starting with `/` are resolvable from the project/repository root (when someone runs markdown-link-check) in the repository root). This is helpful as e.g. github renders `/` urls relative to the repository url in the UI and not relative to github.com completely. 
```json
{
    "replacementPatterns": [
        {
            "pattern": "^/",
            "replacement": "{{BASEURL}}/"
        }
    ]
}

```

fixes #16 
fixes #120 