### PR TITLE
support of environment variables in httpheaders and replacement patterns

### DIFF
--- a/test/special-replacements.md
+++ b/test/special-replacements.md
@@ -1,0 +1,18 @@
+# Sample
+
+This is a test file leveraging special replacement patterns:
+
+![img](/test/%%ENVVAR_MIXEDCASE_TEST%%) (alive)
+![img](%%ENVVAR_MIXEDCASE_TEST%%) (alive)
+
+![img](/test/%%ENVVAR_UPPERCASE_TEST%%) (alive)
+![img](%%ENVVAR_UPPERCASE_TEST%%) (alive)
+
+![img](/test/%%ENVVAR_LOWERCASE_TEST%%) (alive)
+![img](%%ENVVAR_LOWERCASE_TEST%%) (alive)
+
+![img](/test/%%ENVVAR_WITHSPECIALCHARACTERS_TEST%%) (alive)
+![img](%%ENVVAR_WITHSPECIALCHARACTERS_TEST%%) (alive)
+
+![img](/test/%%ENVVAR_NONEXISTENT_TEST%%hello.jpg) (alive)
+![img](%%ENVVAR_NONEXISTENT_TEST%%hello.jpg) (alive)


### PR DESCRIPTION
This PR introduces a special replacement pattern ```{{env.<env_var_name>}}``` for environment variables, that can be used in httpHeaders and in pattern replacement strings. From my point of view it fixes the problem mentioned in #103.

Once merged, credentials can be passed to markdown-link-check via env vars.
```json
{
  ...
  "httpHeaders": [
    {
      "urls": ["https://example.com"],
      "headers": {
        "Authorization": "Bearer {{env.EXAMPLE_COM_TOKEN}}",
        "Foo": "Bar"
      }
    }
  ],
  ...
}
```