### PR TITLE
release.yml: Create a GH action to publish on NPM repos #153

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,18 @@ on:
     types: created
 
 jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+    - uses: actions/setup-node@v2
+      with:
+        node-version: '10.x'
+        registry-url: 'https://registry.npmjs.org'
+    - run: npm install
+    - run: npm publish
+      env:
+        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   docker-build-and-publish:
     name: "Docker: Build & Publish"
     runs-on: ubuntu-latest


### PR DESCRIPTION
I generated a new npm access token (the "automation" kind), added the secret to the repository, and updated `release.yml`. 

I'm not too familiar with github actions, so please have a look to ensure I did it properly. If everything is OK, I'll repeat for `tcort/link-check` and `tcort/markdown-link-extractor` projects.

Relevant Documentation:
 - https://github.com/actions/setup-node
 - https://docs.github.com/en/free-pro-team@latest/actions/guides/publishing-nodejs-packages