### PR TITLE
Indent console output for each file

### DIFF
--- a/markdown-link-check
+++ b/markdown-link-check
@@ -141,13 +141,13 @@ stream
 function runMarkdownLinkCheck(markdown, opts) {
     markdownLinkCheck(markdown, opts, function (err, results) {
         if (err) {
-            console.error(chalk.red('\nERROR: something went wrong!'));
+            console.error(chalk.red('\n  ERROR: something went wrong!'));
             console.error(err.stack);
             process.exit(1);
         }
 
         if (results.length === 0 && !opts.quiet) {
-            console.log(chalk.yellow('No hyperlinks found!'));
+            console.log(chalk.yellow('  No hyperlinks found!'));
         }
         results.forEach(function (result) {
             // Skip messages for non-deadlinks in quiet mode.
@@ -157,21 +157,21 @@ function runMarkdownLinkCheck(markdown, opts) {
 
             if (opts.verbose) {
                 if (result.err) {
-                    console.log('[%s] %s → Status: %s %s', statusLabels[result.status], result.link, result.statusCode, result.err);
+                    console.log('  [%s] %s → Status: %s %s', statusLabels[result.status], result.link, result.statusCode, result.err);
                 } else {
-                    console.log('[%s] %s → Status: %s', statusLabels[result.status], result.link, result.statusCode);
+                    console.log('  [%s] %s → Status: %s', statusLabels[result.status], result.link, result.statusCode);
                 }
             }
             else {
-                console.log('[%s] %s', statusLabels[result.status], result.link);
+                console.log('  [%s] %s', statusLabels[result.status], result.link);
             }
         });
-        console.log('\n%s links checked.', results.length);
+        console.log('\n  %s links checked.', results.length);
         if (results.some((result) => result.status === 'dead')) {
             let deadLinks = results.filter(result => { return result.status === 'dead'; });
-            console.error(chalk.red('\nERROR: %s dead links found!'), deadLinks.length);
+            console.error(chalk.red('\n  ERROR: %s dead links found!'), deadLinks.length);
             deadLinks.forEach(function (result) {
-                console.log('[%s] %s → Status: %s', statusLabels[result.status], result.link, result.statusCode);
+                console.log('  [%s] %s → Status: %s', statusLabels[result.status], result.link, result.statusCode);
             });
             process.exit(1);
         }


### PR DESCRIPTION
Output is difficult to visually parse when no color is available, such as when looking at GitHub Actions logs using [github-action-markdown-link-check](https://github.com/gaurav-nelson/github-action-markdown-link-check).

![Screenshot from 2021-06-16 15-58-47](https://user-images.githubusercontent.com/1031876/122307144-9db62480-cebe-11eb-8a3c-e3d7584d925e.png)

This should make it much easier to visually divide the logs according to what file they pertain to. This is what it looks like in my console:

![Screenshot from 2021-06-16 16-19-54](https://user-images.githubusercontent.com/1031876/122307187-b6bed580-cebe-11eb-86c9-1ae36f8afbe4.png)
