### PR TITLE
Add pre-commit support

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -1,0 +1,7 @@
+- id: markdown-link-check
+  name: Markdown Link Check
+  description: Extracts links from markdown texts and checks they're all alive (i.e. return status 200 OK).
+  entry: markdown-link-check
+  language: node
+  types: [markdown]
+  stages: [commit, push, manual]


### PR DESCRIPTION
Closes #169.

Add a ` .pre-commit-hooks.yaml` file which allows using `markdown-link-check` as a [pre-commit](https://pre-commit.com) hook.