### PR TITLE
Symlink executable into PATH

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -13,5 +13,7 @@ RUN set -ex; \
     npm install
 # Bundle app source
 COPY . /src
+RUN ln -s /src/markdown-link-check /usr/local/bin/markdown-link-check
+# hadolint ignore=DL3059
 RUN npm test
-ENTRYPOINT [ "/src/markdown-link-check" ]
+ENTRYPOINT [ "markdown-link-check" ]


### PR DESCRIPTION
This makes it easier to use the tool from within the Docker image, for
example when the image is used as environment for a CI job.