### PR TITLE
Fix the anchor regression

### DIFF
--- a/test/hash-links.md
+++ b/test/hash-links.md
@@ -1,5 +1,9 @@
 # Foo
 
+<!-- markdownlint-disable MD033 -->
+<a id="tomato"></a>
+<!-- markdownlint-enable MD033 -->
+
 This is a test.
 
 ## Bar
@@ -13,3 +17,5 @@ The second section is [Bar](#bar).
 ## Uh, oh
 
 There is no section named [Potato](#potato).
+
+There is an anchor named [Tomato](#tomato).

--- a/test/markdown-link-check.test.js
+++ b/test/markdown-link-check.test.js
@@ -346,6 +346,7 @@ describe('markdown-link-check', function () {
                 { link: '#foo', statusCode: 200, err: null, status: 'alive' },
                 { link: '#bar', statusCode: 200, err: null, status: 'alive' },
                 { link: '#potato', statusCode: 404, err: null, status: 'dead' },
+                { link: '#tomato', statusCode: 404, err: null, status: 'alive' },
             ]);
             done();
         });

--- a/test/markdown-link-check.test.js
+++ b/test/markdown-link-check.test.js
@@ -346,7 +346,7 @@ describe('markdown-link-check', function () {
                 { link: '#foo', statusCode: 200, err: null, status: 'alive' },
                 { link: '#bar', statusCode: 200, err: null, status: 'alive' },
                 { link: '#potato', statusCode: 404, err: null, status: 'dead' },
-                { link: '#tomato', statusCode: 404, err: null, status: 'alive' },
+                { link: '#tomato', statusCode: 200, err: null, status: 'alive' },
             ]);
             done();
         });


### PR DESCRIPTION
It seems https://github.com/tcort/markdown-link-check/commit/65221868bb1101bf211f9791037f304eacf908a2 caused a regression with inline `<a>` links.

Trying to see if this is intentional, currently I've only included a unit test to discuss whether the behavior is intentional or not (without including the actual "fix").