### PR TITLE
fix: make --quiet flag only output errors

### DIFF
--- a/markdown-link-check
+++ b/markdown-link-check
@@ -206,7 +206,7 @@ async function runMarkdownLinkCheck(filenameForOutput, markdown, opts) {
                 if(!opts.quiet){
                     console.error(chalk.red('\n  ERROR: %s dead links found!'), deadLinks.length);
                 } else {
-                    console.error(chalk.red('\n  ERROR: %s dead links found in %s!'), deadLinks.length, filenameForOutput);
+                    console.error(chalk.red('\n  ERROR: %s dead links found in %s !'), deadLinks.length, filenameForOutput);
                 }
                 deadLinks.forEach(function (result) {
                     console.log('  [%s] %s → Status: %s', statusLabels[result.status], result.link, result.statusCode);

--- a/markdown-link-check
+++ b/markdown-link-check
@@ -146,7 +146,7 @@ async function processInput(filenameForOutput, stream, opts) {
         markdown += chunk.toString();
     }
 
-    if (filenameForOutput) {
+    if (!opts.quiet && filenameForOutput) {
         console.log(chalk.cyan('\nFILE: ' + filenameForOutput));
     }
 
@@ -164,10 +164,10 @@ async function processInput(filenameForOutput, stream, opts) {
         opts.aliveStatusCodes = config.aliveStatusCodes;
     }
 
-    await runMarkdownLinkCheck(markdown, opts);
+    await runMarkdownLinkCheck(filenameForOutput, markdown, opts);
 }
 
-async function runMarkdownLinkCheck(markdown, opts) {
+async function runMarkdownLinkCheck(filenameForOutput, markdown, opts) {
     return new Promise((resolve, reject) => {
         markdownLinkCheck(markdown, opts, function (err, results) {
             if (err) {
@@ -192,14 +192,22 @@ async function runMarkdownLinkCheck(markdown, opts) {
                         console.log('  [%s] %s → Status: %s', statusLabels[result.status], result.link, result.statusCode);
                     }
                 }
-                else {
+                else if(!opts.quiet) {
                     console.log('  [%s] %s', statusLabels[result.status], result.link);
                 }
             });
-            console.log('\n  %s links checked.', results.length);
+
+            if(!opts.quiet){
+                console.log('\n  %s links checked.', results.length);
+            }
+
             if (results.some((result) => result.status === 'dead')) {
                 let deadLinks = results.filter(result => { return result.status === 'dead'; });
-                console.error(chalk.red('\n  ERROR: %s dead links found!'), deadLinks.length);
+                if(!opts.quiet){
+                    console.error(chalk.red('\n  ERROR: %s dead links found!'), deadLinks.length);
+                } else {
+                    console.error(chalk.red('\n  ERROR: %s dead links found in %s!'), deadLinks.length, filenameForOutput);
+                }
                 deadLinks.forEach(function (result) {
                     console.log('  [%s] %s → Status: %s', statusLabels[result.status], result.link, result.statusCode);
                 });


### PR DESCRIPTION
Closes issue https://github.com/tcort/markdown-link-check/issues/223

#### Before

```text
$ ./markdown-link-check test/* --quiet

FILE: test/file.md

FILE: test/hash-links.md
  [✖] #potato
  [✖] #tomato

  4 links checked.

  ERROR: 2 dead links found!
  [✖] #potato → Status: 404
  [✖] #tomato → Status: 404

FILE: test/hello.jpg

  0 links checked.

FILE: test/local-file.md

FILE: test/markdown-link-check.test.js

  0 links checked.

FILE: test/sample.md

FILE: test/special-replacements.md

```

#### After this change

```text
$ ./markdown-link-check test/* --quiet

  ERROR: 2 dead links found in test/hash-links.md!
  [✖] #potato → Status: 404
  [✖] #tomato → Status: 404
```

### On a file without broken links, it doesn't print anything:

#### Before

```text
$ ./markdown-link-check test/file.md --quiet

FILE: test/file.md
```
#### After
```text
$ ./markdown-link-check test/file.md --quiet
$
```