### PR TITLE
ci: Use array for release type schema

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,7 +2,7 @@ name: Release
 
 on:
   release:
-    types: created
+    types: [created]
 
 jobs:
   build:


### PR DESCRIPTION
Noticed because it was getting flagged in VS Code against the schema validation it has from one of the extentions