### PR TITLE
Updated elgohr/Publish-Docker-Github-Action to a supported version (v5)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/checkout@v3
       - name: "Docker: Build & Publish"
         id: build
-        uses: elgohr/Publish-Docker-Github-Action@master
+        uses: elgohr/Publish-Docker-Github-Action@v5
         with:
           name: ${{ env.IMAGE_NAME }}
           registry: ${{ env.REGISTRY }}


### PR DESCRIPTION
elgohr/Publish-Docker-Github-Action@master is not supported anymore

Next try :)