### PR TITLE
feature: add normalizeAnchors flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,6 +79,7 @@ Parameters:
   * `fallbackRetryDelay` the delay in [zeit/ms](https://www.npmjs.com/package/ms) format. (e.g. `"2000ms"`, `20s`, `1m`) for retries on a 429 response when no `retry-after` header is returned or when it has an invalid value. Default is `60s`.
   * `aliveStatusCodes` a list of HTTP codes to consider as alive.
     Example: `[200,206]`
+  * `normalizeAnchors` normalize anchors before checking (eg. `#A Wonderful Day` -> `#a-wonderful-day`)
 * `callback` function which accepts `(err, results)`.
   * `err` an Error object when the operation cannot be completed, otherwise `null`.
   * `results` an array of objects with the following properties:
@@ -192,6 +193,7 @@ Options:
 * `retryCount` the number of retries to be made on a 429 response. Default `2`.
 * `fallbackRetryDelay` the delay in [zeit/ms](https://www.npmjs.com/package/ms) format. (e.g. `"2000ms"`, `20s`, `1m`) for retries on a 429 response when no `retry-after` header is returned or when it has an invalid value. Default is `60s`.
 * `aliveStatusCodes` a list of HTTP codes to consider as alive.
+* `normalizeAnchors` normalize anchors before checking (eg. `#A Wonderful Day` -> `#a-wonderful-day`)
 
 **Example:**
 

--- a/index.js
+++ b/index.js
@@ -71,7 +71,20 @@ module.exports = function markdownLinkCheck(markdown, opts, callback) {
             total: linksCollection.length
         }) : undefined;
 
-    opts.anchors = anchors;
+    if(opts.normalizeAnchors) {
+        opts.anchors = anchors.map(function(anchor) {
+            if (!anchor.startsWith('#')) {
+                return '';
+            }
+            const sanitizedHeader = decodeURIComponent(anchor.slice(1))
+                .replaceAll(/[ -]/g, '-')
+                .replaceAll(/[^\w-]/g, '')
+                .toLowerCase();
+            return '#' + encodeURIComponent(sanitizedHeader);
+        });
+    } else {
+        opts.anchors = anchors;
+    }
 
     async.mapLimit(linksCollection, 2, function (link, callback) {
         if (opts.ignorePatterns) {

--- a/markdown-link-check
+++ b/markdown-link-check
@@ -165,6 +165,7 @@ async function processInput(filenameForOutput, stream, opts) {
         opts.retryCount = config.retryCount;
         opts.fallbackRetryDelay = config.fallbackRetryDelay;
         opts.aliveStatusCodes = config.aliveStatusCodes;
+        opts.normalizeAnchors = config.normalizeAnchors;
     }
 
     await runMarkdownLinkCheck(filenameForOutput, markdown, opts);

--- a/test/markdown-link-check.test.js
+++ b/test/markdown-link-check.test.js
@@ -340,7 +340,7 @@ describe('markdown-link-check', function () {
             done();
         });
     });
-    it.skip('check hash links', function (done) {
+    it('check hash links', function (done) {
         markdownLinkCheck(fs.readFileSync(path.join(__dirname, 'hash-links.md')).toString(), {}, function (err, result) {
             expect(err).to.be(null);
             expect(result).to.eql([
@@ -348,6 +348,20 @@ describe('markdown-link-check', function () {
                 { link: '#bar', statusCode: 200, err: null, status: 'alive' },
                 { link: '#potato', statusCode: 404, err: null, status: 'dead' },
                 { link: '#tomato', statusCode: 404, err: null, status: 'dead' },
+                { link: '#header-with-special-char-', statusCode: 404, err: null, status: 'dead' },
+            ]);
+            done();
+        });
+    });
+    it('check normalized hash links', function (done) {
+        markdownLinkCheck(fs.readFileSync(path.join(__dirname, 'hash-links.md')).toString(), {normalizeAnchors: true}, function (err, result) {
+            expect(err).to.be(null);
+            expect(result).to.eql([
+                { link: '#foo', statusCode: 200, err: null, status: 'alive' },
+                { link: '#bar', statusCode: 200, err: null, status: 'alive' },
+                { link: '#potato', statusCode: 404, err: null, status: 'dead' },
+                { link: '#tomato', statusCode: 404, err: null, status: 'dead' },
+                { link: '#header-with-special-char-', statusCode: 200, err: null, status: 'alive' },
             ]);
             done();
         });


### PR DESCRIPTION
Towards #250 #225 gaurav-nelson/github-action-markdown-link-check#176

### Summary

Add a flag (to avoid a breaking change) that enables GitHub style anchor link sanitization before checking.

This fixes the skipped anchor link checking test and a few reported issues.
