### PR TITLE
fix failing github action with IPv6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,10 +13,9 @@ jobs:
       fail-fast: false
       matrix:
         node-version:
-          - 14
-          - 16
           - 18
           - 19
+          - 20
 
     steps:
     - uses: actions/checkout@v3

--- a/test/markdown-link-check.test.js
+++ b/test/markdown-link-check.test.js
@@ -81,7 +81,13 @@ describe('markdown-link-check', function () {
                 done(err);
                 return;
             }
-            baseUrl = 'http://' + server.address().address + ':' + server.address().port;
+            // github action uses IPv6 addresses
+            // there seems missing IPv6 support in upstream libs
+            if (server.address().address === "::1") {
+                baseUrl = 'http://localhost:' + server.address().port;
+            } else {
+                baseUrl = 'http://' + server.address().address + ':' + server.address().port;
+            }
             done();
         });
     });


### PR DESCRIPTION
Related to:
- https://github.com/tcort/link-check/pull/71

Node 14 and 16 are EoL.

Since Node 18 github action uses IPv6 (host: ::1). This should in url: [::1].
But any used lib seems to be incompatible.