### PR TITLE
fix failing github action with IPv6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
           - 18
           - 19
 
+    env:
+      NODE_OPTIONS: '--dns-result-order=ipv4first'
     steps:
     - uses: actions/checkout@v3
     - name: Use Node.js ${{ matrix.node-version }}


### PR DESCRIPTION
Since Node 18 github action uses IPv6 (host: ::1). This should in url: [::1].
But any used lib seems to be incompatible.

Replaces:
- #294

Related:
- #295

Fixes:
- #291