### PR TITLE
enable skipped tests for hash links

### DIFF
--- a/test/markdown-link-check.test.js
+++ b/test/markdown-link-check.test.js
@@ -340,7 +340,7 @@ describe('markdown-link-check', function () {
             done();
         });
     });
-    it.skip('check hash links', function (done) {
+    it('check hash links', function (done) {
         markdownLinkCheck(fs.readFileSync(path.join(__dirname, 'hash-links.md')).toString(), {}, function (err, result) {
             expect(err).to.be(null);
             expect(result).to.eql([
@@ -348,6 +348,7 @@ describe('markdown-link-check', function () {
                 { link: '#bar', statusCode: 200, err: null, status: 'alive' },
                 { link: '#potato', statusCode: 404, err: null, status: 'dead' },
                 { link: '#tomato', statusCode: 404, err: null, status: 'dead' },
+                { link: '#header-with-special-char-', statusCode: 404, err: null, status: 'dead' },
             ]);
             done();
         });


### PR DESCRIPTION
Enable tests for hash links and adds missing result for (broken, added by https://github.com/tcort/markdown-link-check/commit/c4068d7fe317e2c8414bcc49a770d9b7b38c6810) `#header-with-special-char-`.

Revert https://github.com/tcort/markdown-link-check/commit/98ba6bfd6d14147a7d63e9f52ad6352428a400e6

At the moment the pipeline is failing because of current broken release.
It shows the failure reason for
- #304 