### PR TITLE
Check GitHub markdown section links

### DIFF
--- a/markdown-link-check
+++ b/markdown-link-check
@@ -100,7 +100,13 @@ function getInputs() {
                         continue;
                     }
 
-                    baseUrl = 'file://' + path.dirname(resolved);
+                    if (process.platform === 'win32') {
+                        baseUrl = 'file://' + path.dirname(resolved).replace(/\\/g, '/');
+                    }
+                    else {
+                        baseUrl = 'file://' + path.dirname(resolved);
+                    }
+
                     stream = fs.createReadStream(filenameOrUrl);
                 }
 
@@ -124,7 +130,12 @@ function getInputs() {
             input.opts.projectBaseUrl = `file://${program.projectBaseUrl}`;
         } else {
             // set the default projectBaseUrl to the current working directory, so that `{{BASEURL}}` can be resolved to the project root.
-            input.opts.projectBaseUrl = `file://${process.cwd()}`;
+            if (process.platform === 'win32') {
+                input.opts.projectBaseUrl = `file:///${process.cwd().replace(/\\/g, '/')}`;
+            }
+            else {
+                input.opts.projectBaseUrl = `file://${process.cwd()}`;
+            }
         }
     }
 

--- a/test/section-links.md
+++ b/test/section-links.md
@@ -1,0 +1,36 @@
+# section links test
+
+We will test GitHub markdown links to headings. Correct links should resolve
+while misspellings should result in a 404.
+
+## Level two heading
+
+#### Level four heading
+
+### Test Same Name repeating
+
+##### Test same Name Repeating
+
+```bash
+# This is a comment in a code block
+```
+
+Link to [Level two heading](#level-two-heading) should work.
+
+Link to [Misspelled Level two heading](#level-two-headingg) should 404.
+
+Link to [Level four heading](#level-four-heading) should work.
+
+Link to [Test Same Name repeating](#test-same-name-repeating) should work.
+
+Link to [Second Test same Name Repeating](#test-same-name-repeating-1) should work.
+
+Link to [Third nonexistent Test same Name Repeating](#test-same-name-repeating-2) should 404.
+
+Link to [comment in code block](#this-is-a-comment-in-a-code-block) should 404.
+
+Link to [Level two heading using baseurl](https://BASEURL#level-two-heading) should work.
+
+Link to [Level two heading using baseurl with slash](https://BASEURL/#level-two-heading) should work.
+
+Link to [Level two heading using baseurl with slashes](https://BASEURL////#level-two-heading) should work.


### PR DESCRIPTION
Extract markdown heading lines and convert to section link names, check all section links against this list and return a 404 for any that do not have a heading.

Filter out code blocks because comments can be false positives for markdown headers.

Make some minor adjustments for the tests to pass on Windows.

Fix #250