### PR TITLE
feat: add support for unicode characters in anchor links

### DIFF
--- a/index.js
+++ b/index.js
@@ -49,9 +49,30 @@ function extractSections(markdown) {
 
     const sectionTitles = markdown.match(/^#+ .*$/gm) || [];
 
-    const sections = sectionTitles.map(section =>
-        section.replace(/^\W+/, '').replace(/\W+$/, '').replace(/[^\w\s-]+/g, '').replace(/\s+/g, '-').toLowerCase()
-    );
+    const sections = sectionTitles.map(section => {
+        // replace links, the links can start with "./", "/", "http://", "https://" or "#"
+        // and keep the value of the text ($1)
+        section = section.replace(/\[(.+)\]\(((?:\.?\/|https?:\/\/|#)[\w\d./?=#-]+)\)/, "$1")
+        // make everything (Unicode-aware) lower case
+        section = section.toLowerCase();
+        // remove white spaces and "#" at the beginning
+        section = section.replace(/^#+\s*/, '')
+        // remove everything that is NOT a (Unicode) Letter, (Unicode) Number decimal,
+        // (Unicode) Number letter, white space, underscore or hyphen
+        section = section.replace(/[^\p{L}\p{Nd}\p{Nl}\s_\-`]/gu, "");
+        // remove sequences of *
+        section = section.replace(/\*(?=.*)/gu, "");
+        // remove leftover backticks
+        section = section.replace(/`/gu, "");
+        // Now replace remaining blanks with '-'
+        section = section.replace(/\s/gu, "-");
+        // The links are compared with the headings (simple text comparison).
+        // However, the links are url-encoded beforehand, so the headings
+        // have to also be encoded so that they can also be matched.
+        section = encodeURIComponent(section)
+
+        return section;
+    });
 
     var uniq = {};
     for (var section of sections) {

--- a/index.js
+++ b/index.js
@@ -49,30 +49,30 @@ function extractSections(markdown) {
 
     const sectionTitles = markdown.match(/^#+ .*$/gm) || [];
 
-    const sections = sectionTitles.map(section => {
-        // replace links, the links can start with "./", "/", "http://", "https://" or "#"
-        // and keep the value of the text ($1)
-        section = section.replace(/\[(.+)\]\(((?:\.?\/|https?:\/\/|#)[\w\d./?=#-]+)\)/, "$1")
-        // make everything (Unicode-aware) lower case
-        section = section.toLowerCase();
-        // remove white spaces and "#" at the beginning
-        section = section.replace(/^#+\s*/, '')
-        // remove everything that is NOT a (Unicode) Letter, (Unicode) Number decimal,
-        // (Unicode) Number letter, white space, underscore or hyphen
-        section = section.replace(/[^\p{L}\p{Nd}\p{Nl}\s_\-`]/gu, "");
-        // remove sequences of *
-        section = section.replace(/\*(?=.*)/gu, "");
-        // remove leftover backticks
-        section = section.replace(/`/gu, "");
-        // Now replace remaining blanks with '-'
-        section = section.replace(/\s/gu, "-");
+    const sections = sectionTitles.map(section =>
         // The links are compared with the headings (simple text comparison).
         // However, the links are url-encoded beforehand, so the headings
         // have to also be encoded so that they can also be matched.
-        section = encodeURIComponent(section)
-
-        return section;
-    });
+        encodeURIComponent(
+            section
+                // replace links, the links can start with "./", "/", "http://", "https://" or "#"
+                // and keep the value of the text ($1)
+                .replace(/\[(.+)\]\(((?:\.?\/|https?:\/\/|#)[\w\d./?=#-]+)\)/, "$1")
+                // make everything (Unicode-aware) lower case
+                .toLowerCase()
+                // remove white spaces and "#" at the beginning
+                .replace(/^#+\s*/, '')
+                // remove everything that is NOT a (Unicode) Letter, (Unicode) Number decimal,
+                // (Unicode) Number letter, white space, underscore or hyphen
+                .replace(/[^\p{L}\p{Nd}\p{Nl}\s_\-`]/gu, "")
+                // remove sequences of *
+                .replace(/\*(?=.*)/gu, "")
+                // remove leftover backticks
+                .replace(/`/gu, "")
+                // Now replace remaining blanks with '-'
+                .replace(/\s/gu, "-")
+        )
+    );
 
     var uniq = {};
     for (var section of sections) {

--- a/index.js
+++ b/index.js
@@ -64,6 +64,7 @@ function extractSections(markdown) {
                 .replace(/^#+\s*/, '')
                 // remove everything that is NOT a (Unicode) Letter, (Unicode) Number decimal,
                 // (Unicode) Number letter, white space, underscore or hyphen
+                // https://ruby-doc.org/3.3.2/Regexp.html#class-Regexp-label-Unicode+Character+Categories
                 .replace(/[^\p{L}\p{Nd}\p{Nl}\s_\-`]/gu, "")
                 // remove sequences of *
                 .replace(/\*(?=.*)/gu, "")

--- a/test/hash-links.md
+++ b/test/hash-links.md
@@ -20,6 +20,34 @@ There is no section named [Potato](#potato).
 
 There is an anchor named [Tomato](#tomato).
 
-## Header with special char ✨
+## Header with special char at end ✨
 
-Test [header with image](#header-with-special-char-)
+Test [header with image](#header-with-special-char-at-end-)
+
+## Header with multiple special chars at end ✨✨
+
+Test [header with multiple images](#header-with-multiple-special-chars-at-end-)
+
+## Header with special ✨ char
+
+Test [header with image](#header-with-special--char)
+
+## Header with multiple special ✨✨ chars
+
+Test [header with multiple images](#header-with-multiple-special--chars)
+
+## Header with German umlaut Ö
+
+Link to [German umlaut Ö](#header-with-german-umlaut-ö)
+
+## Header with German umlaut ö manual encoded link
+
+Link to [German umlaut ö manual encoded in link](#header-with-german-umlaut-%C3%B6-manual-encoded-link)
+
+### [Heading with a link](https://github.com/tcort/markdown-link-check)
+
+An [anchor link](#heading-with-a-link) to a heading.
+
+### [Heading with an anchor link](#foo)
+
+An [anchor link](#heading-with-an-anchor-link) to a heading.

--- a/test/hash-links.md
+++ b/test/hash-links.md
@@ -14,6 +14,8 @@ The title is [Foo](#foo).
 
 The second section is [Bar](#bar).
 
+To test a failure. Link that [does not exist](#does-not-exist).
+
 ## Uh, oh
 
 There is no section named [Potato](#potato).

--- a/test/hash-links.md
+++ b/test/hash-links.md
@@ -65,3 +65,15 @@ An [anchor link](#heading-with-an-anchor-link) to a heading.
 ## Product Owner / Design Approval
 
 [Product Owner / Design Approval](#product-owner--design-approval)
+
+## Migrating from `<= v1.18.0`
+
+Whitespaces separated by special characters (no workaround)
+
+[migrating from <= v1.18.0](#migrating-from--v1180)
+
+## Client/server examples using  `network.peer.*
+
+Consequent whitespaces typo (easy to workaround)
+
+[Client/server examples using `network.peer.*`](#clientserver-examples-using--networkpeer)

--- a/test/hash-links.md
+++ b/test/hash-links.md
@@ -83,3 +83,9 @@ Consequent whitespaces typo (easy to workaround)
 This is a [link to a linked header](#this-header-is-linked)
 
 ### Somewhere
+
+## L. Is the package in the Linux distro base image?
+
+Anchor links ending with `?`.
+
+[L. Is the package in the Linux distro base image?](#l-is-the-package-in-the-linux-distro-base-image)

--- a/test/hash-links.md
+++ b/test/hash-links.md
@@ -77,3 +77,9 @@ Whitespaces separated by special characters (no workaround)
 Consequent whitespaces typo (easy to workaround)
 
 [Client/server examples using `network.peer.*`](#clientserver-examples-using--networkpeer)
+
+## This header is [linked](#somewhere)
+
+This is a [link to a linked header](#this-header-is-linked)
+
+### Somewhere

--- a/test/hash-links.md
+++ b/test/hash-links.md
@@ -53,3 +53,15 @@ An [anchor link](#heading-with-a-link) to a heading.
 ### [Heading with an anchor link](#foo)
 
 An [anchor link](#heading-with-an-anchor-link) to a heading.
+
+## --docker
+
+[--docker](#--docker)
+
+## Step 7 - Lint & Test
+
+[Step 7 - Lint \& Test](#step-7---lint--test)
+
+## Product Owner / Design Approval
+
+[Product Owner / Design Approval](#product-owner--design-approval)

--- a/test/markdown-link-check.test.js
+++ b/test/markdown-link-check.test.js
@@ -378,7 +378,15 @@ describe('markdown-link-check', function () {
                 { link: '#bar', statusCode: 200, err: null, status: 'alive' },
                 { link: '#potato', statusCode: 404, err: null, status: 'dead' },
                 { link: '#tomato', statusCode: 404, err: null, status: 'dead' },
-                { link: '#header-with-special-char-', statusCode: 404, err: null, status: 'dead' },
+                { link: '#header-with-special-char-at-end-', statusCode: 200, err: null, status: 'alive' },
+                { link: '#header-with-multiple-special-chars-at-end-', statusCode: 200, err: null, status: 'alive' },
+                { link: '#header-with-special--char', statusCode: 200, err: null, status: 'alive' },
+                { link: '#header-with-multiple-special--chars', statusCode: 200, err: null, status: 'alive' },
+                { link: '#header-with-german-umlaut-%C3%B6', statusCode: 200, err: null, status: 'alive' },
+                { link: '#header-with-german-umlaut-%C3%B6-manual-encoded-link', statusCode: 200, err: null, status: 'alive' },
+                { link: 'https://github.com/tcort/markdown-link-check', statusCode: 200, err: null, status: 'alive' },
+                { link: '#heading-with-a-link', statusCode: 200, err: null, status: 'alive' },
+                { link: '#heading-with-an-anchor-link', statusCode: 200, err: null, status: 'alive' },
             ]);
             done();
         });

--- a/test/markdown-link-check.test.js
+++ b/test/markdown-link-check.test.js
@@ -376,6 +376,7 @@ describe('markdown-link-check', function () {
             expect(result).to.eql([
                 { link: '#foo', statusCode: 200, err: null, status: 'alive' },
                 { link: '#bar', statusCode: 200, err: null, status: 'alive' },
+                { link: '#does-not-exist', statusCode: 404, err: null, status: 'dead' },
                 { link: '#potato', statusCode: 404, err: null, status: 'dead' },
                 { link: '#tomato', statusCode: 404, err: null, status: 'dead' },
                 { link: '#header-with-special-char-at-end-', statusCode: 200, err: null, status: 'alive' },

--- a/test/markdown-link-check.test.js
+++ b/test/markdown-link-check.test.js
@@ -388,6 +388,9 @@ describe('markdown-link-check', function () {
                 { link: 'https://github.com/tcort/markdown-link-check', statusCode: 200, err: null, status: 'alive' },
                 { link: '#heading-with-a-link', statusCode: 200, err: null, status: 'alive' },
                 { link: '#heading-with-an-anchor-link', statusCode: 200, err: null, status: 'alive' },
+                { link: '#--docker', statusCode: 200, err: null, status: 'alive' },
+                { link: '#step-7---lint--test', statusCode: 200, err: null, status: 'alive' },
+                { link: '#product-owner--design-approval', statusCode: 200, err: null, status: 'alive' },
             ]);
             done();
         });

--- a/test/markdown-link-check.test.js
+++ b/test/markdown-link-check.test.js
@@ -393,6 +393,8 @@ describe('markdown-link-check', function () {
                 { link: '#product-owner--design-approval', statusCode: 200, err: null, status: 'alive' },
                 { link: '#migrating-from--v1180', statusCode: 200, err: null, status: 'alive' },
                 { link: '#clientserver-examples-using--networkpeer', statusCode: 200, err: null, status: 'alive' },
+                { link: '#somewhere', statusCode: 200, err: null, status: 'alive' },
+                { link: '#this-header-is-linked', statusCode: 200, err: null, status: 'alive' },
             ]);
             done();
         });

--- a/test/markdown-link-check.test.js
+++ b/test/markdown-link-check.test.js
@@ -395,6 +395,7 @@ describe('markdown-link-check', function () {
                 { link: '#clientserver-examples-using--networkpeer', statusCode: 200, err: null, status: 'alive' },
                 { link: '#somewhere', statusCode: 200, err: null, status: 'alive' },
                 { link: '#this-header-is-linked', statusCode: 200, err: null, status: 'alive' },
+                { link: '#l-is-the-package-in-the-linux-distro-base-image', statusCode: 200, err: null, status: 'alive' },
             ]);
             done();
         });

--- a/test/markdown-link-check.test.js
+++ b/test/markdown-link-check.test.js
@@ -391,6 +391,8 @@ describe('markdown-link-check', function () {
                 { link: '#--docker', statusCode: 200, err: null, status: 'alive' },
                 { link: '#step-7---lint--test', statusCode: 200, err: null, status: 'alive' },
                 { link: '#product-owner--design-approval', statusCode: 200, err: null, status: 'alive' },
+                { link: '#migrating-from--v1180', statusCode: 200, err: null, status: 'alive' },
+                { link: '#clientserver-examples-using--networkpeer', statusCode: 200, err: null, status: 'alive' },
             ]);
             done();
         });


### PR DESCRIPTION
Allows you to check and use unicode characters in anchor links (e.g. german umlauts or emojis)

follow up / improvement of:
- #312 

fixes:
- #325
- #358
- #348
- #360

probably fixes:
- #337

parts are based on:
- [anchor link handling](https://github.com/Moonbase59/gh-toc/blob/222135269ed1990d3d79c3b8d7ce1594a35966ea/gh-toc.js#L156-L174)
- [parsing markdown links](https://davidwells.io/snippets/regex-match-markdown-links)
- [Regex docs](https://ruby-doc.org/3.3.2/Regexp.html#class-Regexp-label-Unicode+Character+Categories)
- [similar to markdownlint](https://github.com/DavidAnson/markdownlint/blob/b2305efafb034b1f328845aec9928b5363ffd646/lib/md051.js#L45)

also added some tests