### PR TITLE
fix: add used `@eslint/js` to dev dependencies in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -23,6 +23,7 @@
         "markdown-link-check": "markdown-link-check"
       },
       "devDependencies": {
+        "@eslint/js": "^9.3.0",
         "eslint": "^9.3.0",
         "expect.js": "^0.3.1",
         "express": "^4.19.2",

--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "proxy-agent": "^6.4.0"
   },
   "devDependencies": {
+    "@eslint/js": "^9.3.0",
     "eslint": "^9.3.0",
     "expect.js": "^0.3.1",
     "express": "^4.19.2",


### PR DESCRIPTION
I did a check with: `npx npm-check`

and get:

`@eslint/js    😟  PKG ERR!  Not in the package.json. Found in: /eslint.config.mjs`

Reason:
- #318 