### PR TITLE
feat: anchor link checks support HTML tags like `<a name="foo"></a>`

### DIFF
--- a/index.js
+++ b/index.js
@@ -56,8 +56,8 @@ function extractHtmlSections(markdown) {
         // remove single line code (if not escaped with "\")
         .replace(/(?<!\\)`[\S\s]+?(?<!\\)`/gm, '');
 
-    const regexAllId = /<(?<tag>[^\s]+).*?id="(?<id>[^"]*?)".*?>/gmi;
-    const regexAName = /<a.*?name="(?<name>[^"]*?)".*?>/gmi;
+    const regexAllId = /<(?<tag>[^\s]+).*?id=["'](?<id>[^"']*?)["'].*?>/gmi;
+    const regexAName = /<a.*?name=["'](?<name>[^"']*?)["'].*?>/gmi;
 
     const sections = []
         .concat(Array.from(markdown.matchAll(regexAllId), (match) => match.groups.id))

--- a/test/hash-links.md
+++ b/test/hash-links.md
@@ -1,10 +1,27 @@
 # Foo
 
 <!-- markdownlint-disable MD033 -->
-<a id="tomato"></a>
+<a id="tomato_id"></a>
+
+<a name="tomato_name"></a>
+
+<div id="onion"></div>
+<div id="onion_outer">
+    <div id="onion_inner"></div>
+</div>
+
+<!--
+<a id="tomato_comment"></a>
+-->
+
 <!-- markdownlint-enable MD033 -->
 
 This is a test.
+
+HTML anchor in code `<a id="tomato_code"></a>` should be ignored.
+
+<!-- markdownlint-disable-next-line MD033 -->
+Ignore escaped backticks \`<a id="tomato_escaped_backticks"></a>\`. Link should work.
 
 ## Bar
 
@@ -18,7 +35,21 @@ The second section is [Bar](#bar).
 
 There is no section named [Potato](#potato).
 
-There is an anchor named [Tomato](#tomato).
+There is an anchor named with `id` [Tomato](#tomato_id).
+
+There is an anchor named with `name` [Tomato](#tomato_name).
+
+There is an anchor in code [Tomato in code](#tomato_code).
+
+There is an anchor in escaped code [Tomato in escaped backticks](#tomato_escaped_backticks).
+
+There is an anchor in HTML comment [Tomato in comment](#tomato_comment).
+
+There is an anchor in single div [Onion](#onion).
+
+There is an anchor in outer div [Onion outer](#onion_outer).
+
+There is an anchor in inner div [Onion inner](#onion_inner).
 
 ## Header with special char ✨
 

--- a/test/hash-links.md
+++ b/test/hash-links.md
@@ -2,8 +2,10 @@
 
 <!-- markdownlint-disable MD033 -->
 <a id="tomato_id"></a>
-
 <a name="tomato_name"></a>
+
+<a id='tomato_id_single_quote'></a>
+<a name='tomato_name_single_quote'></a>
 
 <div id="onion"></div>
 <div id="onion_outer">
@@ -38,6 +40,10 @@ There is no section named [Potato](#potato).
 There is an anchor named with `id` [Tomato](#tomato_id).
 
 There is an anchor named with `name` [Tomato](#tomato_name).
+
+There is an anchor named with `id` [Tomato in single quote](#tomato_id_single_quote).
+
+There is an anchor named with `name` [Tomato in single quote](#tomato_name_single_quote).
 
 There is an anchor in code [Tomato in code](#tomato_code).
 

--- a/test/markdown-link-check.test.js
+++ b/test/markdown-link-check.test.js
@@ -379,6 +379,8 @@ describe('markdown-link-check', function () {
                 { link: '#potato', statusCode: 404, err: null, status: 'dead' },
                 { link: '#tomato_id', statusCode: 200, err: null, status: 'alive' },
                 { link: '#tomato_name', statusCode: 200, err: null, status: 'alive' },
+                { link: '#tomato_id_single_quote', statusCode: 200, err: null, status: 'alive' },
+                { link: '#tomato_name_single_quote', statusCode: 200, err: null, status: 'alive' },
                 { link: '#tomato_code', statusCode: 404, err: null, status: 'dead' },
                 { link: '#tomato_escaped_backticks', statusCode: 200, err: null, status: 'alive' },
                 { link: '#tomato_comment', statusCode: 404, err: null, status: 'dead' },

--- a/test/markdown-link-check.test.js
+++ b/test/markdown-link-check.test.js
@@ -377,7 +377,14 @@ describe('markdown-link-check', function () {
                 { link: '#foo', statusCode: 200, err: null, status: 'alive' },
                 { link: '#bar', statusCode: 200, err: null, status: 'alive' },
                 { link: '#potato', statusCode: 404, err: null, status: 'dead' },
-                { link: '#tomato', statusCode: 404, err: null, status: 'dead' },
+                { link: '#tomato_id', statusCode: 200, err: null, status: 'alive' },
+                { link: '#tomato_name', statusCode: 200, err: null, status: 'alive' },
+                { link: '#tomato_code', statusCode: 404, err: null, status: 'dead' },
+                { link: '#tomato_escaped_backticks', statusCode: 200, err: null, status: 'alive' },
+                { link: '#tomato_comment', statusCode: 404, err: null, status: 'dead' },
+                { link: '#onion', statusCode: 200, err: null, status: 'alive' },
+                { link: '#onion_outer', statusCode: 200, err: null, status: 'alive' },
+                { link: '#onion_inner', statusCode: 200, err: null, status: 'alive' },
                 { link: '#header-with-special-char-', statusCode: 404, err: null, status: 'dead' },
             ]);
             done();


### PR DESCRIPTION
Extracts all html tags with the attribute `id` and all `a` tags with the attribute `name` and allows them as valid section links.

Ignore:
- code blocks (` ``` `)
- single code (`` ` ``)
- html comments

Fits the lint rule [MD51](https://github.com/DavidAnson/markdownlint/blob/main/doc/md051.md)

> Alternatively, any HTML tag with an `id` attribute or an `a` tag with a `name` attribute can be used to define a fragment


fixes:
- #202
- #195 

related to:
- #328 
