### PR TITLE
Update hook names

### DIFF
--- a/.pre-commit-hooks.yaml
+++ b/.pre-commit-hooks.yaml
@@ -4,4 +4,4 @@
   entry: markdown-link-check
   language: node
   types: [markdown]
-  stages: [commit, push, manual]
+  stages: [pre-commit, pre-push, manual]


### PR DESCRIPTION
Currently I see
```
[WARNING] repo `https://github.com/tcort/markdown-link-check` uses deprecated stage names (commit, push) which will be removed in a future version.  Hint: often `pre-commit autoupdate --repo https://github.com/tcort/markdown-link-check` will fix this.  if it does not -- consider reporting an issue to that repo.
```

When using this hook. I think, based on [this](https://pre-commit.com/#confining-hooks-to-run-at-certain-stages) (and specifically the note `new in 3.2.0: The values of stages match the hook names. Previously, commit, push, and merge-commit matched pre-commit, pre-push, and pre-merge-commit respectively.`) that this will fix that warning. I've allowed edits to this branch, so feel free to edit yourself or request changes!

Thank you for making this hook, it is very useful :smile: 