### PR TITLE
ci: bump nodejs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,7 +19,8 @@ jobs:
         node-version:
           - 18
           - 20
-          - 21
+          - 22
+          - 23
 
     env:
       NODE_OPTIONS: '--dns-result-order=ipv4first'


### PR DESCRIPTION
Nodejs 21 is EoL: https://endoflife.date/nodejs