### PR TITLE
Do not override reporter option if not defined in config file (issue #369)

### DIFF
--- a/markdown-link-check
+++ b/markdown-link-check
@@ -288,7 +288,7 @@ async function processInput(filenameForOutput, stream, opts) {
         opts.retryCount = config.retryCount;
         opts.fallbackRetryDelay = config.fallbackRetryDelay;
         opts.aliveStatusCodes = config.aliveStatusCodes;
-        opts.reporters = config.reporters;
+        opts.reporters = config.reporters ?? opts.reporters;
     }
 
     await runMarkdownLinkCheck(filenameForOutput, markdown, opts);


### PR DESCRIPTION
Fix https://github.com/tcort/markdown-link-check/issues/369