### PR TITLE
docs: migrate Docker instructions to relative bind mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Docker images are built with each release. Use the `stable` tag for the current 
 Add current directory with your `README.md` file as read only volume to `docker run`:
 
 ```shell
-docker run -v ${PWD}:/tmp:ro --rm -i ghcr.io/tcort/markdown-link-check:stable /tmp/README.md
+docker run -v .:/tmp:ro --rm -i ghcr.io/tcort/markdown-link-check:stable /tmp/README.md
 ```
 
 Alternatively, if you wish to target a specific release, images are tagged with semantic versions (i.e. `3`, `3.8`, `3.8.3`)


### PR DESCRIPTION
## Issue

The [README > Run using Docker](https://github.com/tcort/markdown-link-check/blob/master/README.md#run-using-docker) command example

```shell
docker run -v ${PWD}:/tmp:ro --rm -i ghcr.io/tcort/markdown-link-check:stable /tmp/README.md
```

uses `PWD` (Print Working Directory). The syntax `${PWD}` can now be replaced by a simpler one using relative paths.

## Relative paths

The Docker documentation for [`docker container run`](https://docs.docker.com/reference/cli/docker/container/run/) (with alias `docker run`) describes the option [Mount volume (-v)](https://docs.docker.com/reference/cli/docker/container/run/#volume) using relative paths:

> As of Docker Engine version 23, you can use relative paths on the host.
>
> `docker  run  -v ./content:/content -w /content -i -t  ubuntu pwd`

- [Docker Engine 23.0.0](https://docs.docker.com/engine/release-notes/23.0/#bug-fixes-and-enhancements-6) was released on Feb 1, 2023. The current version is
- [Docker Engine 27.3.1](https://docs.docker.com/engine/release-notes/27/) released on Sep 20, 2024.

## Change

Use the relative path `.` syntax instead of `${PWD}`:

```shell
docker run -v .:/tmp:ro --rm -i ghcr.io/tcort/markdown-link-check:stable /tmp/README.md
```

## Verification

Under Ubuntu `24.04.1` LTS

```shell
git clone https://github.com/tcort/markdown-link-check
cd markdown-link-check
docker run -v .:/tmp:ro --rm -i ghcr.io/tcort/markdown-link-check:stable /tmp/README.md
```

Confirm that `markdown-link-check` runs successfully.