### PR TITLE
Use default reporter when none specified in config

### DIFF
--- a/markdown-link-check
+++ b/markdown-link-check
@@ -288,7 +288,7 @@ async function processInput(filenameForOutput, stream, opts) {
         opts.retryCount = config.retryCount;
         opts.fallbackRetryDelay = config.fallbackRetryDelay;
         opts.aliveStatusCodes = config.aliveStatusCodes;
-        opts.reporters = config.reporters;
+        opts.reporters = config.reporters ?? opts.reporters;
     }
 
     await runMarkdownLinkCheck(filenameForOutput, markdown, opts);


### PR DESCRIPTION
This addresses https://github.com/tcort/markdown-link-check/issues/369, where using a config file that doesn't specify a reporter breaks. We update the code so that when there's a config without a reporter, we fallback to the default one.