### PR TITLE
docs: migrate Docker instructions to relative bind mount

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Docker images are built with each release. Use the `stable` tag for the current 
 Add current directory with your `README.md` file as read only volume to `docker run`:
 
 ```shell
-docker run -v ${PWD}:/tmp:ro --rm -i ghcr.io/tcort/markdown-link-check:stable /tmp/README.md
+docker run -v .:/tmp:ro --rm -i ghcr.io/tcort/markdown-link-check:stable /tmp/README.md
 ```
 
 Alternatively, if you wish to target a specific release, images are tagged with semantic versions (i.e. `3`, `3.8`, `3.8.3`)


### PR DESCRIPTION
- supersedes #374 (which I previously closed after waiting more than 2 months for a response)

## Issue

The [README > Run using Docker](https://github.com/tcort/markdown-link-check/blob/master/README.md#run-using-docker) command example

```shell
docker run -v ${PWD}:/tmp:ro --rm -i ghcr.io/tcort/markdown-link-check:stable /tmp/README.md
```

uses `PWD` (Print Working Directory). The syntax `${PWD}` can now be replaced by a simpler one using relative paths.

## Relative paths

The Docker documentation for [`docker container run`](https://docs.docker.com/reference/cli/docker/container/run/) (with alias `docker run`) describes the option [Mount volume (-v)](https://docs.docker.com/reference/cli/docker/container/run/#volume) using relative paths:

> As of Docker Engine version 23, you can use relative paths on the host.
>
> `docker  run  -v ./content:/content -w /content -i -t  ubuntu pwd`

- [Docker Engine 23.0.0](https://docs.docker.com/engine/release-notes/23.0/#bug-fixes-and-enhancements-6) was released on Feb 1, 2023. The current version is
- [Docker Engine 28.0.1](https://docs.docker.com/engine/release-notes/28/) released on Feb 26, 2025.

## Change

Use the relative path `.` syntax instead of `${PWD}`:

```shell
docker run -v .:/tmp:ro --rm -i ghcr.io/tcort/markdown-link-check:stable /tmp/README.md
```

## Verification

For example, under Ubuntu `24.04.2` LTS

```shell
git clone https://github.com/tcort/markdown-link-check
cd markdown-link-check
docker run -v .:/tmp:ro --rm -i ghcr.io/tcort/markdown-link-check:stable /tmp/README.md
```

Confirm that `markdown-link-check` runs successfully.

### Logs

```text
$ docker run -v .:/tmp:ro --rm -i ghcr.io/tcort/markdown-link-check:stable /tmp/README.md
Unable to find image 'ghcr.io/tcort/markdown-link-check:stable' locally
stable: Pulling from tcort/markdown-link-check
43c4264eed91: Pull complete
453ca8c35a67: Pull complete
7a291b8a7b57: Pull complete
15929fe50b42: Pull complete
c70efbd48e66: Pull complete
4f4fb700ef54: Pull complete
0e06fe306355: Pull complete
b28c781acdb5: Pull complete
5e49cffc8ea6: Pull complete
68f40888b8a2: Pull complete
Digest: sha256:b812aa72676ed310c045d2c89d56abc1f88dd06e68edbea982799a7ff01c8569
Status: Downloaded newer image for ghcr.io/tcort/markdown-link-check:stable

FILE: /tmp/README.md
  [✓] https://www.npmjs.com/package/isemail
  [✓] https://github.com/gaurav-nelson/github-action-markdown-link-check
  [✓] https://pre-commit.com
  [✓] https://megalinter.io/latest/
  [✓] https://megalinter.io/latest/descriptors/markdown_markdown_link_check/
  [✓] https://www.npmjs.com/package/ms
  [✓] https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/String/replace#specifying_a_string_as_the_replacement
  [✓] https://github.com/tcort/markdown-link-check/blob/master/LICENSE.md
  [✓] https://github.com/tcort/markdown-link-check/actions/workflows/ci.yml/badge.svg

  9 links checked.
```
