### PR TITLE
chore(admin): Automate admin for stale issues and pull requests

### DIFF
--- a/.github/workflows/close-stale-issues-and-pull-requests.yml
+++ b/.github/workflows/close-stale-issues-and-pull-requests.yml
@@ -1,0 +1,19 @@
+name: 'Close stale issues and pull requests'
+on:
+  schedule:
+    - cron: '8 8 * * *'
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          stale-issue-message: 'This issue has been marked as stale because it has been open 60 days with no activity. It will be closed in 30 days unless the stale label is removed or someone adds a comment.'
+          stale-pr-message: 'This pull request has been marked as stale because it has been open 60 days with no activity. It will be closed in 30 days unless the stale label is removed or someone adds a comment.'
+          close-issue-message: 'This issue was closed because it has been marked as stale for 30 days with no activity.'
+          close-pr-message: 'This pull request was closed because it has been marked as stale for 30 days with no activity.'
+          days-before-issue-stale: 60
+          days-before-pr-stale: 60
+          days-before-issue-close: 30
+          days-before-pr-close: 30


### PR DESCRIPTION
I expect loads of the existing issues are no longer relevant as they apply to earlier versions etc.

This should help reduce the current (and ongoing) triage load.