### PR TITLE
change links checked output from !quiet to verbose

### DIFF
--- a/markdown-link-check
+++ b/markdown-link-check
@@ -55,7 +55,7 @@ const reporters = {
             }
         });
 
-        if (!opts.quiet) {
+        if (opts.verbose) {
             console.log("\n  %s link%s checked.", results.length, results.length === 1 ? '' : 's');
         }
 


### PR DESCRIPTION
- closes #395

This doesn't technically remove the line. It just changes the guard from `!quiet` to `verbose`. I'm also willing to remove it entirely, but as there is a `verbose` flag, it seemed _somewhat_ worthwhile to honor that instead of just removing the output entirely.