### PR TITLE
Use $(pwd) instead of . for docker run

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Docker images are built with each release. Use the `stable` tag for the current 
 Add current directory with your `README.md` file as read only volume to `docker run`:
 
 ```shell
-docker run -v .:/tmp:ro --rm -i ghcr.io/tcort/markdown-link-check:stable /tmp/README.md
+docker run -v $(pwd):/tmp:ro --rm -i ghcr.io/tcort/markdown-link-check:stable /tmp/README.md
 ```
 
 Alternatively, if you wish to target a specific release, images are tagged with semantic versions (i.e. `3`, `3.8`, `3.8.3`)


### PR DESCRIPTION
not sure if it is my docker version, but using `.` as a volume does not work for me:
```
$ docker run -v .:/tmp:ro --rm -i ghcr.io/tcort/markdown-link-check:stable /tmp/README.md
docker: Error response from daemon: create .: volume name is too short, names should be at least two alphanumeric characters.
See 'docker run --help'.

$ docker run -v $(pwd):/tmp:ro --rm -i ghcr.io/tcort/markdown-link-check:stable /tmp/README.md

FILE: /tmp/README.md
  [✓] ...
```