### PR TITLE
docs: remove reference to isemail - no longer used

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,8 +7,7 @@
 # markdown-link-check
 
 Extracts links from markdown texts and checks whether each link is
-alive (`200 OK`) or dead. `mailto:` links are validated with
-[isemail](https://www.npmjs.com/package/isemail).
+alive (`200 OK`) or dead. `mailto:` links are also validated.
 
 ## Installation
 


### PR DESCRIPTION
- closes https://github.com/tcort/markdown-link-check/issues/371

## Issue

The [README](https://github.com/tcort/markdown-link-check/blob/master/README.md) introduces itself with the description:

> Extracts links from markdown texts and checks whether each link is alive (`200 OK`) or dead. `mailto:` links are validated with [isemail](https://www.npmjs.com/package/isemail).

The reference to [isemail](https://www.npmjs.com/package/isemail) is however no longer correct.

[markdown-link-check@3.13.7](https://github.com/tcort/markdown-link-check/releases/tag/v3.13.7) (current `latest`):

1. has no dependency on [isemail](https://www.npmjs.com/package/isemail)
2. delegates `mailto:` link checking to [link-check@^5.4.0](https://github.com/tcort/link-check/tree/v5.4.0)

[link-check@^5.4.0](https://github.com/tcort/link-check/tree/v5.4.0) uses [node-email-verifier](https://www.npmjs.com/package/node-email-verifier) and has dropped the use of [isemail](https://www.npmjs.com/package/isemail)

## Change

Remove the reference to [isemail](https://www.npmjs.com/package/isemail) in the [README](https://github.com/tcort/markdown-link-check/blob/master/README.md) document and no longer mention any specific module, since the choice is delegated to [link-check](https://www.npmjs.com/package/link-check).
