### PR TITLE
fix: return exit code 1 when dead links found

### DIFF
--- a/markdown-link-check
+++ b/markdown-link-check
@@ -303,7 +303,7 @@ async function runMarkdownLinkCheck(filenameForOutput, markdown, opts) {
     ));
 
     if (err) throw null;
-    else if (results.some((result) => result.status === 'dead')) return;
+    else if (results.some((result) => result.status === 'dead')) throw null;
     else return;
 }
 


### PR DESCRIPTION
The CLI used to return exit code 1 when dead links found until version 3.12.2, but it changed to exit code 0 in [this commit](https://github.com/tcort/markdown-link-check/commit/d8f522b10d74b55e93a4677b9f1b9f0f314e94d6) (This seems unintentional as the behavior change not mentioned)

This PR change the exit code back to the original (1) when there are dead links.