### PR TITLE
docs: update link to maintained github action

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Alternatively, if you wish to target a specific release, images are tagged with 
 
 ## Run in a GitHub action
 
-Please head on to [github-action-markdown-link-check](https://github.com/gaurav-nelson/github-action-markdown-link-check).
+Please head on to [github-action-markdown-link-check](https://github.com/tcort/github-action-markdown-link-check).
 
 ## Run as a pre-commit hook
 


### PR DESCRIPTION
Since you have forked the github action, I figured it would be simpler to just link to that one :)