### PR TITLE
Quarto (.qmd) support

### DIFF
--- a/markdown-link-check
+++ b/markdown-link-check
@@ -102,7 +102,7 @@ function loadAllMarkdownFiles(rootFolder = '.') {
         const fullPath = path.join(rootFolder, file);
         if (fs.lstatSync(fullPath).isDirectory()) {
             files.push(...loadAllMarkdownFiles(fullPath));
-        } else if (fullPath.endsWith('.md')) {
+        } else if (fullPath.endsWith('.md') || fullPath.endsWith('.qmd')) {
             files.push(fullPath);
         }
     });


### PR DESCRIPTION
Quarto is a markdown format that integrates Jupyter notebooks and other graphics.

https://quarto.org/

Would be nice to also check for .qmd files and report dead links.
