### PR TITLE
ci: increase number of days before automatic closing

### DIFF
--- a/.github/workflows/close-stale-issues-and-pull-requests.yml
+++ b/.github/workflows/close-stale-issues-and-pull-requests.yml
@@ -9,11 +9,11 @@ jobs:
     steps:
       - uses: actions/stale@v9
         with:
-          stale-issue-message: 'This issue has been marked as stale because it has been open 60 days with no activity. It will be closed in 30 days unless the stale label is removed or someone adds a comment.'
-          stale-pr-message: 'This pull request has been marked as stale because it has been open 60 days with no activity. It will be closed in 30 days unless the stale label is removed or someone adds a comment.'
-          close-issue-message: 'This issue was closed because it has been marked as stale for 30 days with no activity.'
-          close-pr-message: 'This pull request was closed because it has been marked as stale for 30 days with no activity.'
-          days-before-issue-stale: 60
-          days-before-pr-stale: 60
-          days-before-issue-close: 30
-          days-before-pr-close: 30
+          stale-issue-message: 'This issue has been marked as stale because it has been open 60 days with no activity. It will be closed in 90 days unless the stale label is removed or someone adds a comment.'
+          stale-pr-message: 'This pull request has been marked as stale because it has been open 60 days with no activity. It will be closed in 90 days unless the stale label is removed or someone adds a comment.'
+          close-issue-message: 'This issue was closed because it has been marked as stale for 90 days with no activity.'
+          close-pr-message: 'This pull request was closed because it has been marked as stale for 90 days with no activity.'
+          days-before-issue-stale: 90
+          days-before-pr-stale: 90
+          days-before-issue-close: 90
+          days-before-pr-close: 90


### PR DESCRIPTION
Hi @BaseMax @WillGibson ,

W all have a job in addition to managing this repo so I think that 30 days is definitely too short for automatic closing

Does it sounds good to you if we increase the number of days ?