### PR TITLE
Implement JUnit reporter

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 .tern-port
 junit.xml
+temp/*

--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Parameters:
   * `fallbackRetryDelay` the delay in [ms](https://www.npmjs.com/package/ms) format. (e.g. `"2000ms"`, `20s`, `1m`) for retries on a 429 response when no `retry-after` header is returned or when it has an invalid value. Default is `60s`.
   * `aliveStatusCodes` a list of HTTP codes to consider as alive.
     Example: `[200,206]`
+  * `reporters` an array of reporter functions to use for outputting results. If not specified, default output will be generated (useful when using the API programmatically). Available built-in reporters can be imported from the command-line tool.
 * `callback` function which accepts `(err, results)`.
   * `err` an Error object when the operation cannot be completed, otherwise `null`.
   * `results` an array of objects with the following properties:
@@ -200,8 +201,59 @@ Options:
   -r, --retry             retry after the duration indicated in 'retry-after' header when HTTP code is 429
   --reporters <names>     specify reporters to use
   --projectBaseUrl <url>  the URL to use for {{BASEURL}} replacement
+  --junit-output <file>   output file for JUnit XML report (only used with junit reporter)
   -h, --help              display help for command
 ```
+
+##### Reporters
+
+`markdown-link-check` supports multiple output reporters to format the results of link checking:
+
+###### Default Reporter
+
+The default reporter outputs results to the console with colored status indicators:
+
+```shell
+markdown-link-check README.md
+```
+
+Output format:
+
+```text
+  ✓ https://example.com/valid-link
+  ✖ https://example.com/broken-link
+  / https://example.com/ignored-link
+
+  3 links checked.
+
+  ERROR: 1 dead links found!
+```
+
+###### JUnit Reporter
+
+The JUnit reporter generates XML output compatible with JUnit test result format, useful for CI/CD integration:
+
+```shell
+markdown-link-check --reporters junit README.md
+```
+
+To specify a custom output file:
+
+```shell
+markdown-link-check --reporters junit --junit-output results.xml README.md
+```
+
+If no output file is specified, the results are written to `junit-results.xml` by default.
+
+###### Multiple Reporters
+
+You can use multiple reporters simultaneously by specifying them in a comma-separated list:
+
+```shell
+markdown-link-check --reporters default,junit README.md
+```
+
+This will output to both the console (default reporter) and generate a JUnit XML file.
 
 ##### Config file format
 

--- a/markdown-link-check
+++ b/markdown-link-check
@@ -73,6 +73,107 @@ const reporters = {
             });
         }
     },
+    junit: async function junitReporter(err, results, opts, filenameForOutput) {
+        const path = require('path');
+        
+        const totalTests = results.length;
+        const failedTests = results.filter(result => result.status === 'dead' || result.status === 'error').length;
+        const skippedTests = results.filter(result => result.status === 'ignored').length;
+        const passedTests = totalTests - failedTests - skippedTests;
+        
+        const timestamp = new Date().toISOString();
+        const testSuiteName = filenameForOutput ? path.basename(filenameForOutput, '.md') : 'markdown-link-check';
+        
+        let xml = '<?xml version="1.0" encoding="UTF-8"?>\n';
+        xml += `<testsuites name="markdown-link-check" tests="${totalTests}" failures="${failedTests}" skipped="${skippedTests}" time="0">\n`;
+        xml += `  <testsuite name="${testSuiteName}" tests="${totalTests}" failures="${failedTests}" skipped="${skippedTests}" time="0" timestamp="${timestamp}">\n`;
+        
+        xml += '    <properties>\n';
+        if (filenameForOutput) {
+            xml += `      <property name="file" value="${escapeXml(filenameForOutput)}"/>\n`;
+        }
+        xml += '    </properties>\n';
+        
+        results.forEach(function(result, index) {
+            const testName = `link-${index + 1}`;
+            const className = testSuiteName;
+            
+            xml += `    <testcase name="${escapeXml(testName)}" classname="${escapeXml(className)}" time="0">\n`;
+            
+            // Add test case properties
+            xml += '      <properties>\n';
+            xml += `        <property name="url" value="${escapeXml(result.link)}"/>\n`;
+            xml += `        <property name="status" value="${escapeXml(result.status)}"/>\n`;
+            if (result.statusCode !== undefined) {
+                xml += `        <property name="statusCode" value="${result.statusCode}"/>\n`;
+            }
+            xml += '      </properties>\n';
+            
+            // Handle failures and errors
+            if (result.status === 'dead') {
+                const message = `Dead link: ${result.link} (Status: ${result.statusCode})`;
+                xml += `      <failure message="${escapeXml(message)}" type="DeadLink">\n`;
+                xml += `        <![CDATA[Link: ${result.link}\nStatus Code: ${result.statusCode}\nStatus: ${result.status}`;
+                if (result.err) {
+                    xml += `\nError: ${result.err}`;
+                }
+                xml += ']]>\n';
+                xml += '      </failure>\n';
+            } else if (result.status === 'error') {
+                const message = `Error checking link: ${result.link}`;
+                xml += `      <error message="${escapeXml(message)}" type="LinkCheckError">\n`;
+                xml += `        <![CDATA[Link: ${result.link}\nStatus Code: ${result.statusCode}\nStatus: ${result.status}`;
+                if (result.err) {
+                    xml += `\nError: ${result.err}`;
+                }
+                xml += ']]>\n';
+                xml += '      </error>\n';
+            } else if (result.status === 'ignored') {
+                xml += `      <skipped message="Link ignored: ${escapeXml(result.link)}"/>\n`;
+            }
+            
+            xml += '    </testcase>\n';
+        });
+        
+        // Handle global errors
+        if (err) {
+            xml += `    <testcase name="markdown-link-check-error" classname="${escapeXml(testSuiteName)}" time="0">\n`;
+            xml += `      <error message="${escapeXml(err.message || 'Unknown error')}" type="ProcessingError">\n`;
+            xml += `        <![CDATA[${err.stack || err.message || err}]]>\n`;
+            xml += '      </error>\n';
+            xml += '    </testcase>\n';
+        }
+        
+        xml += '  </testsuite>\n';
+        xml += '</testsuites>\n';
+        
+        const outputFile = opts.junitOutput || 'junit-results.xml';
+        
+        try {
+            fs.writeFileSync(outputFile, xml, 'utf8');
+            if (!opts.quiet) {
+                console.log(`JUnit report written to: ${outputFile}`);
+            }
+        } catch (writeErr) {
+            console.error(`Error writing JUnit report: ${writeErr.message}`);
+        }
+        
+        function escapeXml(unsafe) {
+            if (typeof unsafe !== 'string') {
+                return String(unsafe);
+            }
+            return unsafe.replace(/[<>&'"]/g, function (c) {
+                switch (c) {
+                    case '<': return '&lt;';
+                    case '>': return '&gt;';
+                    case '&': return '&amp;';
+                    case '\'': return '&apos;';
+                    case '"': return '&quot;';
+                    default: return c;
+                }
+            });
+        }
+    },
 };
 
 class Input {
@@ -127,6 +228,7 @@ function getInputs() {
         .option('-r, --retry', 'retry after the duration indicated in \'retry-after\' header when HTTP code is 429')
         .option('--reporters <names>', 'specify reporters to use', commaSeparatedReportersList)
         .option('--projectBaseUrl <url>', 'the URL to use for {{BASEURL}} replacement')
+        .option('--junit-output <file>', 'output file for JUnit XML report (only used with junit reporter)')
         .arguments('[filenamesOrDirectorynamesOrUrls...]')
         .action(function (filenamesOrUrls) {
             let filenameForOutput;
@@ -214,6 +316,7 @@ function getInputs() {
         input.opts.retryOn429 = (program.opts().retry === true);
         input.opts.aliveStatusCodes = program.opts().alive;
         input.opts.reporters = program.opts().reporters ?? [ reporters.default ];
+        input.opts.junitOutput = program.opts().junitOutput;
         const config = program.opts().config;
         if (config) {
             input.opts.config = config.trim();

--- a/test/junit-reporter.test.js
+++ b/test/junit-reporter.test.js
@@ -1,0 +1,273 @@
+'use strict';
+
+const fs = require('fs');
+const path = require('path');
+const expect = require('expect.js');
+const { spawn } = require('child_process');
+
+describe('JUnit Reporter', function () {
+    let tempDir;
+    
+    before(function () {
+        tempDir = path.join(__dirname, 'temp');
+        if (!fs.existsSync(tempDir)) {
+            fs.mkdirSync(tempDir);
+        }
+    });
+
+    after(function () {
+        if (fs.existsSync(tempDir)) {
+            const files = fs.readdirSync(tempDir);
+            files.forEach(file => {
+                fs.unlinkSync(path.join(tempDir, file));
+            });
+            fs.rmdirSync(tempDir);
+        }
+    });
+
+    it('should generate valid JUnit XML for a markdown file with mixed link results', function (done) {
+        this.timeout(15000); // Increase timeout for network requests
+
+        const testMarkdown = `# Test File
+
+## Working Links
+- [Google](https://www.google.com)
+- [GitHub](https://github.com)
+
+## Local Links
+- [README](./README.md)
+- [Package](./package.json)
+
+## Dead Links
+- [Non-existent](https://this-site-definitely-does-not-exist-12345.com)
+`;
+        
+        const testFile = path.join(tempDir, 'test-markdown.md');
+        const outputFile = path.join(tempDir, 'junit-output.xml');
+        
+        fs.writeFileSync(testFile, testMarkdown);
+
+        const cliPath = path.join(__dirname, '..', 'markdown-link-check');
+        const child = spawn('node', [
+            cliPath,
+            '--reporters', 'junit',
+            '--junit-output', outputFile,
+            testFile
+        ], {
+            stdio: 'pipe'
+        });
+
+        let stdout = '';
+
+        child.stdout.on('data', (data) => {
+            stdout += data.toString();
+        });
+
+        child.on('close', () => {
+            try {
+                expect(fs.existsSync(outputFile)).to.be(true);
+
+                const xmlContent = fs.readFileSync(outputFile, 'utf8');
+                
+                expect(xmlContent).to.contain('<?xml version="1.0" encoding="UTF-8"?>');
+                expect(xmlContent).to.contain('<testsuites name="markdown-link-check"');
+                expect(xmlContent).to.contain('<testsuite name="test-markdown"');
+                expect(xmlContent).to.contain('</testsuites>');
+
+                // Should have multiple test cases (at least 5 links)
+                const testCaseMatches = xmlContent.match(/<testcase/g);
+                expect(testCaseMatches).to.be.ok();
+                expect(testCaseMatches.length).to.be.greaterThan(4);
+
+                // Should contain expected URLs
+                expect(xmlContent).to.contain('https://www.google.com');
+                expect(xmlContent).to.contain('https://github.com');
+                expect(xmlContent).to.contain('./README.md');
+                expect(xmlContent).to.contain('./package.json');
+                expect(xmlContent).to.contain('this-site-definitely-does-not-exist-12345.com');
+
+                // Should have at least one failure (the non-existent site)
+                expect(xmlContent).to.contain('<failure');
+                expect(xmlContent).to.contain('type="DeadLink"');
+
+                expect(xmlContent).to.contain('<testcase name="link-1"');
+                expect(xmlContent).to.contain('<properties>');
+                expect(xmlContent).to.contain('<property name="url"');
+                expect(xmlContent).to.contain('<property name="status"');
+                expect(xmlContent).to.contain('<property name="statusCode"');
+
+                // Verify counts make sense
+                const testsMatch = xmlContent.match(/tests="(\d+)"/);
+                const failuresMatch = xmlContent.match(/failures="(\d+)"/);
+                const skippedMatch = xmlContent.match(/skipped="(\d+)"/);
+                
+                expect(testsMatch).to.be.ok();
+                expect(failuresMatch).to.be.ok();
+                expect(skippedMatch).to.be.ok();
+                
+                const totalTests = parseInt(testsMatch[1]);
+                const failures = parseInt(failuresMatch[1]);
+                const skipped = parseInt(skippedMatch[1]);
+                
+                expect(totalTests).to.be.greaterThan(0);
+                expect(failures).to.be.greaterThan(0); // Should have at least one dead link
+                expect(skipped).to.be.greaterThan(-1); // Can be 0 or more
+
+                expect(stdout).to.contain('JUnit report written to:');
+
+                done();
+            } catch (error) {
+                done(error);
+            }
+        });
+
+        child.on('error', (error) => {
+            done(error);
+        });
+    });
+
+    it('should generate JUnit XML with default filename when not specified', function (done) {
+        this.timeout(10000);
+
+        const testMarkdown = `# Simple Test
+- [Google](https://www.google.com)
+`;
+        
+        const testFile = path.join(tempDir, 'simple-test.md');
+        fs.writeFileSync(testFile, testMarkdown);
+
+        const defaultOutputFile = 'junit-results.xml';
+        
+        if (fs.existsSync(defaultOutputFile)) {
+            fs.unlinkSync(defaultOutputFile);
+        }
+
+        // Run markdown-link-check with junit reporter but no output file specified
+        const cliPath = path.join(__dirname, '..', 'markdown-link-check');
+        const child = spawn('node', [
+            cliPath,
+            '--reporters', 'junit',
+            testFile
+        ], {
+            stdio: 'pipe'
+        });
+
+        child.on('close', () => {
+            try {
+                expect(fs.existsSync(defaultOutputFile)).to.be(true);
+
+                const xmlContent = fs.readFileSync(defaultOutputFile, 'utf8');
+                expect(xmlContent).to.contain('<?xml version="1.0" encoding="UTF-8"?>');
+                expect(xmlContent).to.contain('https://www.google.com');
+
+                // Clean up
+                fs.unlinkSync(defaultOutputFile);
+
+                done();
+            } catch (error) {
+                done(error);
+            }
+        });
+
+        child.on('error', (error) => {
+            done(error);
+        });
+    });
+
+    it('should work with both default and junit reporters', function (done) {
+        this.timeout(10000);
+
+        const testMarkdown = `# Combined Test
+- [Google](https://www.google.com)
+- [GitHub](https://github.com)
+`;
+        
+        const testFile = path.join(tempDir, 'combined-test.md');
+        const outputFile = path.join(tempDir, 'combined-output.xml');
+        
+        fs.writeFileSync(testFile, testMarkdown);
+
+        const cliPath = path.join(__dirname, '..', 'markdown-link-check');
+        const child = spawn('node', [
+            cliPath,
+            '--reporters', 'default,junit',
+            '--junit-output', outputFile,
+            testFile
+        ], {
+            stdio: 'pipe'
+        });
+
+        let stdout = '';
+
+        child.stdout.on('data', (data) => {
+            stdout += data.toString();
+        });
+
+        child.on('close', () => {
+            try {
+                // Should have both console output and XML file
+                expect(stdout).to.contain('✓'); // Default reporter output
+                expect(stdout).to.contain('links checked'); // Default reporter summary
+                expect(stdout).to.contain('JUnit report written to:'); // JUnit reporter message
+
+                expect(fs.existsSync(outputFile)).to.be(true);
+                const xmlContent = fs.readFileSync(outputFile, 'utf8');
+                expect(xmlContent).to.contain('https://www.google.com');
+                expect(xmlContent).to.contain('https://github.com');
+
+                done();
+            } catch (error) {
+                done(error);
+            }
+        });
+
+        child.on('error', (error) => {
+            done(error);
+        });
+    });
+
+    it('should handle XML escaping properly in file names', function (done) {
+        this.timeout(10000);
+
+        const testMarkdown = `# Escaping Test
+- [Simple Link](https://www.google.com)
+`;
+        
+        const testFile = path.join(tempDir, 'escaping-test & file.md');
+        const outputFile = path.join(tempDir, 'escaping-output.xml');
+        
+        fs.writeFileSync(testFile, testMarkdown);
+
+        const cliPath = path.join(__dirname, '..', 'markdown-link-check');
+        const child = spawn('node', [
+            cliPath,
+            '--reporters', 'junit',
+            '--junit-output', outputFile,
+            testFile
+        ], {
+            stdio: 'pipe'
+        });
+
+        child.on('close', () => {
+            try {
+                expect(fs.existsSync(outputFile)).to.be(true);
+                
+                const xmlContent = fs.readFileSync(outputFile, 'utf8');
+                
+                // Verify XML escaping occurred in file name and test suite name
+                expect(xmlContent).to.contain('escaping-test &amp; file'); // & should be escaped in file name
+                
+                expect(xmlContent).to.contain('<?xml version="1.0" encoding="UTF-8"?>');
+                expect(xmlContent).to.contain('https://www.google.com');
+
+                done();
+            } catch (error) {
+                done(error);
+            }
+        });
+
+        child.on('error', (error) => {
+            done(error);
+        });
+    });
+});


### PR DESCRIPTION
This PR addresses #424. To not break the build from #364, I simply added a `junit` reported to the `reporters` objet, allowing to report on:

* Calculate total tests, failed tests, skipped tests, and passed tests
* Generate JUnit XML
* Handle all link status