### PR TITLE
Remove @WillGibson from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # Owner @tcort
-# Supported by @smainil @BaseMax @WillGibson
+# Supported by @smainil @BaseMax
 * @tcort @smainil @BaseMax


### PR DESCRIPTION
I'm not using makrdown-link-check in my current role and my life is not allowing me time to contribute, so the emails are too much "noise" for me at the moment 😞 

If that changes, I'll come back and add myself back in.