### PR TITLE
ci: remove Node.js 18 and 23, add 24 to test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,10 +17,9 @@ jobs:
           - windows-latest
           - macos-latest
         node-version:
-          - 18
           - 20
           - 22
-          - 23
+          - 24
 
     env:
       NODE_OPTIONS: '--dns-result-order=ipv4first'


### PR DESCRIPTION
## Situation

The "Test library" workflow [.github/workflows/ci.yml](https://github.com/tcort/markdown-link-check/blob/master/.github/workflows/ci.yml) is using Node.js versions that have reached end-of-life, and is not testing against the current version of Node.js.

Referring to the [Node.js release schedule](https://github.com/nodejs/release#release-schedule) the following release transitions have occurred:

| Node.js | Status      | Date       |
| ------- | ----------- | ---------- |
| `18.x`  | End-of-Life | 2025-04-30 |
| `23.x`  | End-of-Life | 2025-06-01 |
| `24.x`  | Release     | 2025-05-06 |

## Change

For the "Test library" workflow [.github/workflows/ci.yml](https://github.com/tcort/markdown-link-check/blob/master/.github/workflows/ci.yml):

remove
- Node.js 18
- Node.js 23

add
- Node.js 24