### PR TITLE
ci: add Node.js 25 to test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -20,6 +20,7 @@ jobs:
           - 20
           - 22
           - 24
+          - 25
 
     env:
       NODE_OPTIONS: '--dns-result-order=ipv4first'


### PR DESCRIPTION
## Situation

The "Test library" workflow [.github/workflows/ci.yml](https://github.com/tcort/markdown-link-check/blob/master/.github/workflows/ci.yml) is not yet testing against the current version of Node.js.

Referring to the [Node.js release schedule](https://github.com/nodejs/release#release-schedule) the following release transition has occurred:

| Node.js | Transition  | Date       | Status     |
| ------- | ----------- | ---------- | ---------- |
| `25.x`  | Release     | 2025-10-15 | Current    |

## Change

For the "Test library" workflow [.github/workflows/ci.yml](https://github.com/tcort/markdown-link-check/blob/master/.github/workflows/ci.yml):

add
- Node.js 25