### PR TITLE
Bundle minor Dependabot PRs and make monthly

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,7 @@ updates:
   - package-ecosystem: npm
     directory: '/'
     schedule:
-      interval: weekly
+      interval: monthly
     open-pull-requests-limit: 99
     groups:
       dependencies:


### PR DESCRIPTION
With this, Dependabot will open one PR month with all minor/patch updates bundled together. Major version bumps will remain separate PR, along with security PRs.