### PR TITLE
ci: use OIDC NPM publishing

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -4,6 +4,9 @@ on:
   release:
     types: [created]
 
+permissions:
+  id-token: write  # Required for OIDC
+  contents: read
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -11,12 +14,9 @@ jobs:
     - uses: actions/checkout@v5
     - uses: actions/setup-node@v6
       with:
-        node-version: '18.x'
         registry-url: 'https://registry.npmjs.org'
-    - run: npm install
+    - run: npm ci
     - run: npm publish
-      env:
-        NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
   docker-build-and-publish:
     name: "Docker: Build & Publish"
     runs-on: ubuntu-latest


### PR DESCRIPTION
GitHub/NPM are getting rid of the old tokens https://github.blog/changelog/2025-11-05-npm-security-update-classic-token-creation-disabled-and-granular-token-changes/

Changed the release workflow based on https://github.blog/changelog/2025-07-31-npm-trusted-publishing-with-oidc-is-generally-available/ 
and https://docs.npmjs.com/trusted-publishers

There is a change that needs to be made on the NPM side to authorize this workflow.