### PR TITLE
Improve code block removal

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function performSpecialReplacements(str, opts) {
 }
 
 function removeCodeBlocks(markdown) {
-    return markdown.replace(/^```[\S\s]+?^```$/gm, '');
+    return markdown.replace(/^\s+(`{3,}|~{3,})[\S\s]+?^\s+\1$/gm, '');
 }
 
 function extractHtmlSections(markdown) {

--- a/index.js
+++ b/index.js
@@ -43,7 +43,7 @@ function performSpecialReplacements(str, opts) {
 }
 
 function removeCodeBlocks(markdown) {
-    return markdown.replace(/^\s+(`{3,}|~{3,})[\S\s]+?^\s+\1$/gm, '');
+    return markdown.replace(/^[ \t]*(`{3,}|~{3,})[\S\s]+?^[ \t]*\1$/gm, '');
 }
 
 function extractHtmlSections(markdown) {


### PR DESCRIPTION
- Allow leading spaces
- Allow tilde
- Allow more than three backtick or tilde symbols

This is supposed to fix https://github.com/tcort/markdown-link-check/issues/456.

The following test files can be used to compare the behavior before and after the change:

- [`test_imbalanced_backticks.md`](https://github.com/user-attachments/files/28708666/test_imbalanced_backticks.md)
- [`test_indentation.md`](https://github.com/user-attachments/files/28708667/test_indentation.md)
- [`test_multiple_backticks.md`](https://github.com/user-attachments/files/28708669/test_multiple_backticks.md)
- [`test_tilde.md`](https://github.com/user-attachments/files/28708672/test_tilde.md)
